### PR TITLE
Use global total supply instead of L2 supply to calculate participation rate on Arbitrum network

### DIFF
--- a/abis/Minter.json
+++ b/abis/Minter.json
@@ -1,193 +1,5 @@
 [
   {
-    "constant": false,
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_inflationChange",
-        "type": "uint256"
-      }
-    ],
-    "name": "setInflationChange",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "internalType": "contract IMinter",
-        "name": "_newMinter",
-        "type": "address"
-      }
-    ],
-    "name": "migrateToNewMinter",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      { "internalType": "address payable", "name": "_to", "type": "address" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
-    ],
-    "name": "trustedWithdrawETH",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "currentMintedTokens",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "getController",
-    "outputs": [
-      { "internalType": "contract IController", "name": "", "type": "address" }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_targetBondingRate",
-        "type": "uint256"
-      }
-    ],
-    "name": "setTargetBondingRate",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      { "internalType": "uint256", "name": "_fracNum", "type": "uint256" },
-      { "internalType": "uint256", "name": "_fracDenom", "type": "uint256" }
-    ],
-    "name": "createReward",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "targetBondingRate",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      { "internalType": "address", "name": "_controller", "type": "address" }
-    ],
-    "name": "setController",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "currentMintableTokens",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "inflationChange",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "inflation",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
-    ],
-    "name": "trustedBurnTokens",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      { "internalType": "address", "name": "_to", "type": "address" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
-    ],
-    "name": "trustedTransferTokens",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [],
-    "name": "setCurrentRewardTokens",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [],
-    "name": "depositETH",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "payable": true,
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "controller",
-    "outputs": [
-      { "internalType": "contract IController", "name": "", "type": "address" }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       { "internalType": "address", "name": "_controller", "type": "address" },
       { "internalType": "uint256", "name": "_inflation", "type": "uint256" },
@@ -202,9 +14,34 @@
         "type": "uint256"
       }
     ],
-    "payable": false,
     "stateMutability": "nonpayable",
     "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "param",
+        "type": "string"
+      }
+    ],
+    "name": "ParameterUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      }
+    ],
+    "name": "SetController",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -226,29 +63,164 @@
     "type": "event"
   },
   {
-    "anonymous": false,
+    "inputs": [],
+    "name": "controller",
+    "outputs": [
+      { "internalType": "contract IController", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_fracNum", "type": "uint256" },
+      { "internalType": "uint256", "name": "_fracDenom", "type": "uint256" }
+    ],
+    "name": "createReward",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentMintableTokens",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentMintedTokens",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositETH",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getController",
+    "outputs": [
+      { "internalType": "contract IController", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getGlobalTotalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "inflation",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "inflationChange",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "controller",
+        "internalType": "contract IMinter",
+        "name": "_newMinter",
         "type": "address"
       }
     ],
-    "name": "SetController",
-    "type": "event"
+    "name": "migrateToNewMinter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   },
   {
-    "anonymous": false,
+    "inputs": [
+      { "internalType": "address", "name": "_controller", "type": "address" }
+    ],
+    "name": "setController",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "setCurrentRewardTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
-        "indexed": false,
-        "internalType": "string",
-        "name": "param",
-        "type": "string"
+        "internalType": "uint256",
+        "name": "_inflationChange",
+        "type": "uint256"
       }
     ],
-    "name": "ParameterUpdate",
-    "type": "event"
+    "name": "setInflationChange",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_targetBondingRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "setTargetBondingRate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "targetBondingRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+    ],
+    "name": "trustedBurnTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+    ],
+    "name": "trustedTransferTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address payable", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+    ],
+    "name": "trustedWithdrawETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   }
 ]

--- a/networks.yaml
+++ b/networks.yaml
@@ -12,9 +12,12 @@ arbitrum-one:
     livepeerToken:
       address: "289ba1701C2F088cf0faf8B3705246331cB8A839"
       startBlock: 5856156
-    minter:
+    minterV1:
       address: "4969dcCF5186e1c49411638fc8A2a020Fdab752E"
       startBlock: 5856338
+    minter:
+      address: "c20DE37170B45774e6CD3d2304017fc962f27252"
+      startBlock: 6253359
     ticketBroker:
       address: "a8bB618B1520E284046F3dFc448851A1Ff26e41B"
       startBlock: 5856357

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -127,6 +127,34 @@ dataSources:
         - event: ParameterUpdate(string)
           handler: parameterUpdate
   - kind: ethereum/contract
+    name: MinterV1
+    network: {{networkName}}
+    source:
+      startBlock: {{contracts.minterV1.startBlock}}
+      address: {{contracts.minterV1.address}}
+      abi: Minter
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/minter.ts
+      abis:
+        - name: Minter
+          file: ./abis/Minter.json
+        - name: RoundsManager
+          file: ./abis/RoundsManager.json
+      entities:
+        - Round
+        - Transaction
+        - Protocol
+        - ParameterUpdateEvent
+        - SetCurrentRewardTokensEvent
+      eventHandlers:
+        - event: SetCurrentRewardTokens(uint256,uint256)
+          handler: setCurrentRewardTokens
+        - event: ParameterUpdate(string)
+          handler: parameterUpdate
+  - kind: ethereum/contract
     name: Minter
     network: {{networkName}}
     source:
@@ -284,6 +312,8 @@ dataSources:
       language: wasm/assemblyscript
       file: ./src/mappings/livepeerToken.ts 
       abis:
+        - name: Minter
+          file: ./abis/Minter.json
         - name: LivepeerToken
           file: ./abis/LivepeerToken.json
         - name: RoundsManager

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -321,6 +321,16 @@ export function getRoundsManagerAddress(network: string): string {
   }
 }
 
+export function getMinterAddress(network: string): string {
+  if (network == "arbitrum-one") {
+    return "c20DE37170B45774e6CD3d2304017fc962f27252";
+  } else if (network == "arbitrum-rinkeby") {
+    return "E5bE54705D41DAaA33A043aa51dE472ED637C3d9";
+  } else {
+    return "c20DE37170B45774e6CD3d2304017fc962f27252";
+  }
+}
+
 export function getBlockNum(): BigInt {
   let network = dataSource.network();
   let roundsManagerAddress = "";


### PR DESCRIPTION
Fixes issue [#21 on Explorer](https://github.com/livepeer/explorer/issues/21)