### PR TITLE
Remove unbondEvent after transferBond event

### DIFF
--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -1,4 +1,4 @@
-import { store } from "@graphprotocol/graph-ts";
+import { BigInt, store } from "@graphprotocol/graph-ts";
 
 // Import event types from the registrar contract ABIs
 import {
@@ -211,6 +211,9 @@ export function transferBond(event: TransferBond): void {
   transferBondEvent.newUnbondingLockId = event.params.newUnbondingLockId.toI32();
   transferBondEvent.oldUnbondingLockId = event.params.oldUnbondingLockId.toI32();
   transferBondEvent.save();
+
+  // Remove UnbondEvent as the unbondingLock is immediately processed and event is no longer valid
+  store.remove("UnbondEvent", makeEventId(event.transaction.hash, event.logIndex.minus(BigInt.fromI32(1))));
 }
 
 // Handler for Unbond events


### PR DESCRIPTION
An `Unbond` event is emitted when transferring a bond to a different delegator. However, the newly created unbondingLock is immediately processed and the bond is transferred to the new delegator. Due to this extra event, the old delegator gets stuck with an indexed unbond event which [wrongly shows up on the explorer](https://github.com/livepeer/explorer/issues/58).

This PR deletes the indexed UnbondEvent soon after a transferBond event is created. 