### PR TITLE
Track total LPT claimed per Orchestrator

### DIFF
--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -496,6 +496,10 @@ export function reward(event: Reward): void {
   );
   transcoder.lastRewardRound = round.id;
 
+  transcoder.totalRewardsClaimed = transcoder.totalRewardsClaimed.plus(
+    convertToDecimal(event.params.amount)
+  );
+
   pool!.rewardTokens = convertToDecimal(event.params.amount);
   pool!.feeShare = transcoder.feeShare;
   pool!.rewardCut = transcoder.rewardCut;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -224,6 +224,7 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.thirtyDayVolumeETH = ZERO_BD;
     transcoder.sixtyDayVolumeETH = ZERO_BD;
     transcoder.ninetyDayVolumeETH = ZERO_BD;
+    transcoder.totalRewardsClaimed = ZERO_BD;
     transcoder.transcoderDays = [];
     transcoder.save();
   }


### PR DESCRIPTION
Simple PR to track LPT rewards an Orchestrator has claimed in total. Can then be used to fix https://github.com/livepeer/explorer/issues/158

Never worked with the subgraph before, so let me know if there are other changes that need to be done to define this new `totalRewardsClaimed` variable or if the naming needs to change