### PR TITLE
ticketBroker: save broadcaster deductions on winning tickets

### DIFF
--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -76,6 +76,7 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   } else {
     broadcaster.deposit = broadcaster.deposit.minus(faceValue);
   }
+  broadcaster.save();
 
   // Update transcoder's fee volume
   let transcoder = createOrLoadTranscoder(


### PR DESCRIPTION
Previously we did the math but never saved the results and broadcasters deposit and reserve never go down.