### PR TITLE
chore: assign @rickstaa as code-owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rickstaa


### PR DESCRIPTION
This pull request ensures that there is a clear code-owner assigned. I will take this role from the Foundation side.