### PR TITLE
ci: fix deploy action comment matching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           edit-mode: replace
           body: |
-            🚀 **Subgraph studio preview deployed**
+            🚀 **Subgraph Studio preview deployed**
 
             | Item | Details |
             | :--- | :------ |


### PR DESCRIPTION
This pull request fixes a typo in matching string to ensure the action can match earlier posted subgraph studio deploy messages and update them.
