### PR TITLE
ci: put version check in standalone ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,19 +27,3 @@ jobs:
           VERSION_LABEL: ${{ github.ref_name }}
         run: |
           yarn deploy:arbitrum-one -- --version-label "$VERSION_LABEL" --deploy-key "$DEPLOY_KEY"
-  version_check:
-    name: "Check package.json matches tag"
-    runs-on: ubuntu-latest
-    needs: deploy
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Fail if tag mismatches package.json version
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          TAG_NAME="${{ github.ref_name }}"
-          if [ "$TAG_NAME" != "v$PKG_VERSION" ]; then
-            echo "::warning::Tag '$TAG_NAME' does not match package.json version 'v$PKG_VERSION'."
-            exit 1
-          fi

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,24 @@
+name: Tag Version Check
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  version_check:
+    name: "Check package.json matches tag"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Fail if tag mismatches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_NAME="${{ github.ref_name }}"
+          if [ "$TAG_NAME" != "v$PKG_VERSION" ]; then
+            printf "%s\n" \
+              "Tag '$TAG_NAME' does not match package.json version 'v$PKG_VERSION'." \
+              "Please update package.json version to match the latest deployment tag."
+            exit 1
+          fi


### PR DESCRIPTION
# Description

Ensure the version check runs in a seperate action so we can add a badge to the README to update maintainers.

~Fixes # (issue)~

# Checklist

- ~[ ] Ran `yarn prepare:arbitrum-one` and verified `graph codegen` and `graph build` succeed.~
- ~[ ] (Optional) Validated locally with `yarn deploy:local`.~
- ~[ ] Confirmed the Subgraph Studio preview link in the PR comment works and the subgraph syncs without errors.~
