### PR TITLE
ci: deploy graph to Studio as part of CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,4 @@ jobs:
           DEPLOY_KEY: ${{ secrets.ARBITRUM_ONE_DEPLOY_KEY }}
           VERSION_LABEL: ${{ github.ref_name }}
         run: |
-          yarn deploy:arbitrum-one -- --version-label "$VERSION_LABEL" --deploy-key "$DEPLOY_KEY"
+          yarn deploy:arbitrum-one -- --studio --version-label "$VERSION_LABEL" --deploy-key "$DEPLOY_KEY"


### PR DESCRIPTION
# Description

Update the CI deploy workflow to automatically deploy the graph to Studio, preventing CI failures caused by missing product confirmation.

~Fixes # (issue)~

# Checklist

- ~[ ] Ran `yarn prepare:arbitrum-one` and verified `graph codegen` and `graph build` succeed.~
- ~[ ] (Optional) Validated locally with `yarn deploy:local`.~
- ~[ ] Confirmed the Subgraph Studio preview link in the PR comment works and the subgraph syncs without errors.~
