### PR TITLE
ci: remove yarn forward indicator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,4 @@ jobs:
           DEPLOY_KEY: ${{ secrets.ARBITRUM_ONE_DEPLOY_KEY }}
           VERSION_LABEL: ${{ github.ref_name }}
         run: |
-          yarn deploy:arbitrum-one -- --studio --version-label "$VERSION_LABEL" --deploy-key "$DEPLOY_KEY"
+          yarn deploy:arbitrum-one --studio --version-label "$VERSION_LABEL" --deploy-key "$DEPLOY_KEY"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -75,4 +75,4 @@ jobs:
       #     DEPLOY_KEY: ${{ secrets.ARBITRUM_GOERLI_DEPLOY_KEY }}
       #     VERSION_LABEL: ${{ steps.short_sha.outputs.short_sha }}
       #   run: |
-      #     yarn deploy:arbitrum-goerli -- --version-label "$VERSION_LABEL" --deploy-key "$DEPLOY_KEY"
+      #     yarn deploy:arbitrum-goerli --version-label "$VERSION_LABEL" --deploy-key "$DEPLOY_KEY"


### PR DESCRIPTION
# Description

Remove argument forwarding indicator as it is no longer needed by yarn v1.

~Fixes # (issue)~

# Checklist

- ~[ ] Ran `yarn prepare:arbitrum-one` and verified `graph codegen` and `graph build` succeed.~
- ~[ ] (Optional) Validated locally with `yarn deploy:local`.~
- ~[ ] Confirmed the Subgraph Studio preview link in the PR comment works and the subgraph syncs without errors.`~

