### PR TITLE
chore: update version and add version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/livepeer)
 [![Onchain Deploy](https://github.com/livepeer/subgraph/actions/workflows/deploy.yml/badge.svg)](https://github.com/livepeer/subgraph/actions/workflows/deploy.yml)
 [![Staging Deploy](https://github.com/livepeer/subgraph/actions/workflows/staging.yml/badge.svg)](https://github.com/livepeer/subgraph/actions/workflows/staging.yml)
+[![Tag Version Check](https://github.com/livepeer/subgraph/actions/workflows/version-check.yml/badge.svg)](https://github.com/livepeer/subgraph/actions/workflows/version-check.yml)
 
 This package contains the source code for the Livepeer Subgraph, a project for
 indexing and querying Livepeer data from the Ethereum blockchain using

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livepeer/subgraph",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "scripts": {
     "build": "graph build",


### PR DESCRIPTION
# Description

Update the package.json version so it is equal to our deployed version.
Also add a new badge to flag when the version is not correct.

~Fixes # (issue)~

# Checklist

- ~[ ] Ran `yarn prepare:arbitrum-one` and verified `graph codegen` and `graph build` succeed.~
- ~[ ] (Optional) Validated locally with `yarn deploy:local`.~
- ~[ ] Confirmed the Subgraph Studio preview link in the PR comment works and the subgraph syncs without errors.~
