### PR TITLE
docs: update CONTRIBUTION to explain publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
           cache: yarn
       - name: Install
         run: yarn --immutable
-      - name: Deploy to Arbitrum One (tag)
+      - name: Deploy to Subgraph Studio (tag)
         if: startsWith(github.ref, 'refs/tags/')
         env:
           DEPLOY_KEY: ${{ secrets.ARBITRUM_ONE_DEPLOY_KEY }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    name: "Deploy to Subgraph"
+    name: "Deploy to Livepeer CI Subgraph"
 
     runs-on: ubuntu-latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,11 @@ This helps us avoid duplicated effort and align on scope.
 2. Reviewers should confirm the Studio deployment fully syncs without errors.
 3. After approval, merge to `main` to trigger a testnet deployment (currently disabled).
 4. For on-chain releases, update `package.json` version to match the release tag (e.g. `v1.2.3`).
-5. Create a `v*` tag to deploy the on-chain subgraph to the Graph Network.
+5. Create a `v*` tag to deploy a new version to Subgraph Studio (this does not publish to the network).
+
+## Publishing
+
+Publishing to the decentralized network requires a wallet with publish permissions. A wallet admin should complete this step, either from the Studio UI or via the CLI. See the [Graph docs](https://thegraph.com/docs/en/subgraphs/developing/publishing/publishing-a-subgraph/#publishing-from-the-cli).
 
 ## License
 


### PR DESCRIPTION
# Description

Ensure people are aware that we don't automatically publish deployed
graphs.

~Fixes # (issue)~

# Checklist

- ~[ ] Ran `yarn prepare:arbitrum-one` and verified `graph codegen` and `graph build` succeed.~
- ~[ ] (Optional) Validated locally with `yarn deploy:local`.~
- ~[ ] Confirmed the Subgraph Studio preview link in the PR comment works and the subgraph syncs without errors.~
