### PR TITLE
fix: restore gateways to active set after long inactivity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -54,7 +54,7 @@ type Protocol @entity {
   pendingDeactivation: [Transcoder!]!
   "Total number of delegators on the network"
   delegatorsCount: BigInt!
-  "Broadcasters active within the current 90 day fee window"
+  "Broadcasters that paid tickets within the current 90 day fee window"
   activeBroadcasters: [String!]!
 }
 

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -110,7 +110,7 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   protocol.totalVolumeETH = protocol.totalVolumeETH.plus(faceValue);
   protocol.totalVolumeUSD = protocol.totalVolumeUSD.plus(faceValueUSD);
 
-  // Add broadcaster to activeBroadcasters if not already present
+  // Track active broadcasters based on ticket activity.
   let activeBroadcasters = protocol.activeBroadcasters;
   if (!activeBroadcasters.includes(broadcaster.id)) {
     activeBroadcasters.push(broadcaster.id);

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -194,14 +194,6 @@ export function createOrLoadBroadcaster(id: string): Broadcaster {
     broadcaster.save();
   } 
   
-  let protocol = createOrLoadProtocol();
-  let activeBroadcasters = protocol.activeBroadcasters;
-  if (!activeBroadcasters.includes(id)) {
-    activeBroadcasters.push(id);
-    protocol.activeBroadcasters = activeBroadcasters;
-    protocol.save();
-  }
-
   return broadcaster;
 }
 


### PR DESCRIPTION
# Description

Ensure gateways which were inactive for >90 days are added to the active
set again so 30/60/90-day fee sums update.

Fixes # (issue)

# Checklist

- [x] Ran `yarn prepare` and verified `yarn codegen` and `yarn build` succeed.
- [ ] (Optional) Validated locally with `yarn deploy:local`.
- [x] Confirmed the Subgraph Studio preview link in the PR comment works and the subgraph syncs without errors.
