### PR TITLE
feat: cumulative factors and delegator shares for O(1) stake computation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -108,6 +108,8 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
+  "Lifetime cumulative rewards (rewardCut commission) earned by this orchestrator in wei"
+  cumulativeRewards: BigInt!
 }
 
 enum TranscoderStatus @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -108,10 +108,12 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
-  "Unclaimed orchestrator reward commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + pendingRewardCommission"
+  "Unclaimed orchestrator reward commission in wei. Includes both rewardCut commission and rewards earned on staked commission. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + pendingRewardCommission"
   pendingRewardCommission: BigInt!
-  "Lifetime total orchestrator reward commission earned (rewardCut portion) in wei. Never resets."
+  "Lifetime total orchestrator reward commission earned in wei. Never resets."
   lifetimeRewardCommission: BigInt!
+  "Snapshot of pendingRewardCommission at the start of the current round. Used to compute the transcoder's share of delegator rewards earned by its own staked commission. Resets to zero on claim."
+  activeCumulativeRewards: BigInt!
   "Unclaimed orchestrator fee commission in wei. Resets to zero on claim."
   pendingFeeCommission: BigInt!
   "Lifetime total orchestrator fee commission earned in wei. Never resets."

--- a/schema.graphql
+++ b/schema.graphql
@@ -108,7 +108,7 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
-  "Lifetime cumulative rewards (rewardCut commission) earned by this orchestrator in wei"
+  "Unclaimed orchestrator commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + cumulativeRewards"
   cumulativeRewards: BigInt!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -108,10 +108,14 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
-  "Unclaimed orchestrator commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + cumulativeRewards"
-  cumulativeRewards: BigInt!
-  "Lifetime total orchestrator commission earned (rewardCut portion) in wei. Never resets."
-  lifetimeRewards: BigInt!
+  "Unclaimed orchestrator reward commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + pendingRewardCommission"
+  pendingRewardCommission: BigInt!
+  "Lifetime total orchestrator reward commission earned (rewardCut portion) in wei. Never resets."
+  lifetimeRewardCommission: BigInt!
+  "Unclaimed orchestrator fee commission in wei. Resets to zero on claim."
+  pendingFeeCommission: BigInt!
+  "Lifetime total orchestrator fee commission earned in wei. Never resets."
+  lifetimeFeeCommission: BigInt!
 }
 
 enum TranscoderStatus @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -110,6 +110,8 @@ type Transcoder @entity {
   transcoderDays: [TranscoderDay!]!
   "Unclaimed orchestrator commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + cumulativeRewards"
   cumulativeRewards: BigInt!
+  "Lifetime total orchestrator commission earned (rewardCut portion) in wei. Never resets."
+  lifetimeRewards: BigInt!
 }
 
 enum TranscoderStatus @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -135,6 +135,10 @@ type Pool @entity {
   rewardCut: BigInt!
   "Transcoder's fee share during the earnings pool's round"
   feeShare: BigInt!
+  "Cumulative reward factor for computing delegator rewards without looping (27-decimal fixed-point, matches on-chain PreciseMathUtils)"
+  cumulativeRewardFactor: BigInt!
+  "Cumulative fee factor for computing delegator fees without looping (27-decimal fixed-point, matches on-chain PreciseMathUtils)"
+  cumulativeFeeFactor: BigInt!
 }
 
 """
@@ -205,8 +209,30 @@ type Delegator @entity {
   withdrawnFees: BigDecimal!
   "Amount of Livepeer Token the delegator has delegated"
   delegatedAmount: BigDecimal!
+  "Proportional claim on the orchestrator's pool (bondedAmount * 10^27 / crf[lastClaimRound]). Invariant across claims, only changes on bond/unbond."
+  shares: BigInt!
   "Unbonding locks associated with the delegator"
   unbondingLocks: [UnbondingLock!] @derivedFrom(field: "delegator")
+}
+
+"""
+Snapshot of delegator state at each state-changing event, enabling historical stake and reward computation via cumulative factors
+"""
+type DelegatorSnapshot @entity {
+  "Unique identifier: delegator address + round number"
+  id: ID!
+  "The delegator this snapshot belongs to"
+  delegator: Delegator!
+  "The delegate (orchestrator) at the time of this snapshot, null if fully unbonded"
+  delegate: Transcoder
+  "Bonded amount at the time of this snapshot"
+  bondedAmount: BigDecimal!
+  "Proportional claim on the orchestrator's pool. stake = shares * crf[round] / 10^27"
+  shares: BigInt!
+  "Round when this snapshot was taken"
+  round: Round!
+  "Timestamp when this snapshot was taken"
+  timestamp: Int!
 }
 
 """

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -785,6 +785,16 @@ export function earningsClaimed(event: EarningsClaimed): void {
   delegator.fees = delegator.fees.plus(convertToDecimal(event.params.fees));
   delegator.save();
 
+  // Reset orchestrator's unclaimed commission when they claim
+  if (event.params.delegator.toHex() == event.params.delegate.toHex()) {
+    let transcoder = createOrLoadTranscoder(
+      event.params.delegator.toHex(),
+      event.block.timestamp.toI32()
+    );
+    transcoder.cumulativeRewards = ZERO_BI;
+    transcoder.save();
+  }
+
   createOrLoadTransactionFromEvent(event);
 
   let earningsClaimedEvent = new EarningsClaimedEvent(

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -11,6 +11,7 @@ import {
   EMPTY_ADDRESS,
   getBlockNum,
   makeEventId,
+  makePoolId,
   makeUnbondingLockId,
   MAXIMUM_VALUE_UINT256,
   ONE_BI,
@@ -41,6 +42,7 @@ import {
   DelegatorSnapshot,
   EarningsClaimedEvent,
   ParameterUpdateEvent,
+  Pool,
   RebondEvent,
   RewardEvent,
   TranscoderActivatedEvent,
@@ -593,6 +595,9 @@ export function reward(event: Reward): void {
   let totalRewardTokens = event.params.amount; // raw BigInt in wei
   let transcoderCommission = percOf(totalRewardTokens, pool.rewardCut);
   let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
+
+  // Accumulate lifetime orchestrator commission
+  transcoder.cumulativeRewards = transcoder.cumulativeRewards.plus(transcoderCommission);
 
   let totalStakeBI = convertFromDecimal(pool.totalStake);
   if (totalStakeBI.gt(ZERO_BI)) {

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -596,8 +596,9 @@ export function reward(event: Reward): void {
   let transcoderCommission = percOf(totalRewardTokens, pool.rewardCut);
   let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
 
-  // Accumulate lifetime orchestrator commission
+  // Accumulate orchestrator commission
   transcoder.cumulativeRewards = transcoder.cumulativeRewards.plus(transcoderCommission);
+  transcoder.lifetimeRewards = transcoder.lifetimeRewards.plus(transcoderCommission);
 
   let totalStakeBI = convertFromDecimal(pool.totalStake);
   if (totalStakeBI.gt(ZERO_BI)) {

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -596,9 +596,9 @@ export function reward(event: Reward): void {
   let transcoderCommission = percOf(totalRewardTokens, pool.rewardCut);
   let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
 
-  // Accumulate orchestrator commission
-  transcoder.cumulativeRewards = transcoder.cumulativeRewards.plus(transcoderCommission);
-  transcoder.lifetimeRewards = transcoder.lifetimeRewards.plus(transcoderCommission);
+  // Accumulate orchestrator reward commission
+  transcoder.pendingRewardCommission = transcoder.pendingRewardCommission.plus(transcoderCommission);
+  transcoder.lifetimeRewardCommission = transcoder.lifetimeRewardCommission.plus(transcoderCommission);
 
   let totalStakeBI = convertFromDecimal(pool.totalStake);
   if (totalStakeBI.gt(ZERO_BI)) {
@@ -792,7 +792,8 @@ export function earningsClaimed(event: EarningsClaimed): void {
       event.params.delegator.toHex(),
       event.block.timestamp.toI32()
     );
-    transcoder.cumulativeRewards = ZERO_BI;
+    transcoder.pendingRewardCommission = ZERO_BI;
+    transcoder.pendingFeeCommission = ZERO_BI;
     transcoder.save();
   }
 

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -1,5 +1,6 @@
 import { store } from "@graphprotocol/graph-ts";
 import {
+  convertFromDecimal,
   convertToDecimal,
   createOrLoadDelegator,
   createOrLoadPool,
@@ -13,6 +14,9 @@ import {
   makeUnbondingLockId,
   MAXIMUM_VALUE_UINT256,
   ONE_BI,
+  percOf,
+  PRECISE_PERC_DIVISOR,
+  precisePercOf,
   ZERO_BI,
 } from "../../utils/helpers";
 // Import event types from the registrar contract ABIs
@@ -34,6 +38,7 @@ import {
 } from "../types/BondingManager/BondingManager";
 import {
   BondEvent,
+  DelegatorSnapshot,
   EarningsClaimedEvent,
   ParameterUpdateEvent,
   RebondEvent,
@@ -134,11 +139,38 @@ export function bond(event: Bond): void {
     convertToDecimal(event.params.additionalAmount)
   );
 
+  // Compute shares: bondedAmount * 10^27 / crf[lastClaimRound]
+  // shares is invariant across claims, only changes on bond/unbond
+  let poolForShares = Pool.load(
+    makePoolId(event.params.newDelegate.toHex(), round.id)
+  );
+  let sharesRefCRF = PRECISE_PERC_DIVISOR;
+  if (
+    poolForShares &&
+    !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
+  ) {
+    sharesRefCRF = poolForShares.cumulativeRewardFactor;
+  }
+  delegator.shares = event.params.bondedAmount
+    .times(PRECISE_PERC_DIVISOR)
+    .div(sharesRefCRF);
+
   round.save();
   delegate.save();
   delegator.save();
   transcoder.save();
   protocol.save();
+
+  // Save delegator snapshot for historical stake/reward computation
+  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
+  let snapshot = new DelegatorSnapshot(snapshotId);
+  snapshot.delegator = event.params.delegator.toHex();
+  snapshot.delegate = event.params.newDelegate.toHex();
+  snapshot.bondedAmount = delegator.bondedAmount;
+  snapshot.shares = delegator.shares;
+  snapshot.round = round.id;
+  snapshot.timestamp = event.block.timestamp.toI32();
+  snapshot.save();
 
   createOrLoadTransactionFromEvent(event);
 
@@ -259,6 +291,25 @@ export function unbond(event: Unbond): void {
     convertToDecimal(event.params.amount)
   );
 
+  // Compute shares from new bonded amount
+  if (delegatorData.value0.isZero()) {
+    delegator.shares = ZERO_BI;
+  } else {
+    let poolForShares = Pool.load(
+      makePoolId(event.params.delegate.toHex(), round.id)
+    );
+    let sharesRefCRF = PRECISE_PERC_DIVISOR;
+    if (
+      poolForShares &&
+      !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
+    ) {
+      sharesRefCRF = poolForShares.cumulativeRewardFactor;
+    }
+    delegator.shares = delegatorData.value0
+      .times(PRECISE_PERC_DIVISOR)
+      .div(sharesRefCRF);
+  }
+
   // Delegator no longer delegated to anyone if it does not have a bonded amount
   // so remove it from delegate
   if (delegatorData.value0.isZero()) {
@@ -290,6 +341,17 @@ export function unbond(event: Unbond): void {
   delegator.save();
   protocol.save();
   round.save();
+
+  // Save delegator snapshot for historical stake/reward computation
+  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
+  let snapshot = new DelegatorSnapshot(snapshotId);
+  snapshot.delegator = event.params.delegator.toHex();
+  snapshot.delegate = delegator.delegate;
+  snapshot.bondedAmount = delegator.bondedAmount;
+  snapshot.shares = delegator.shares;
+  snapshot.round = round.id;
+  snapshot.timestamp = event.block.timestamp.toI32();
+  snapshot.save();
 
   createOrLoadTransactionFromEvent(event);
 
@@ -351,6 +413,21 @@ export function rebond(event: Rebond): void {
   delegator.bondedAmount = convertToDecimal(delegatorData.value0);
   delegator.fees = convertToDecimal(delegatorData.value1);
 
+  // Compute shares: bondedAmount * 10^27 / crf[lastClaimRound]
+  let poolForShares = Pool.load(
+    makePoolId(event.params.delegate.toHex(), round.id)
+  );
+  let sharesRefCRF = PRECISE_PERC_DIVISOR;
+  if (
+    poolForShares &&
+    !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
+  ) {
+    sharesRefCRF = poolForShares.cumulativeRewardFactor;
+  }
+  delegator.shares = delegatorData.value0
+    .times(PRECISE_PERC_DIVISOR)
+    .div(sharesRefCRF);
+
   // If the sender field for the lock is equal to the delegator's address then
   // we know that this is an unbonding lock the delegator created by calling
   // unbond() and if it is not then we know that this is an unbonding lock created
@@ -370,6 +447,17 @@ export function rebond(event: Rebond): void {
   transcoder.save();
   delegator.save();
   protocol.save();
+
+  // Save delegator snapshot for historical stake/reward computation
+  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
+  let snapshot = new DelegatorSnapshot(snapshotId);
+  snapshot.delegator = event.params.delegator.toHex();
+  snapshot.delegate = event.params.delegate.toHex();
+  snapshot.bondedAmount = delegator.bondedAmount;
+  snapshot.shares = delegator.shares;
+  snapshot.round = round.id;
+  snapshot.timestamp = event.block.timestamp.toI32();
+  snapshot.save();
 
   if (unbondingLock) {
     store.remove("UnbondingLock", uniqueUnbondingLockId);
@@ -493,6 +581,27 @@ export function reward(event: Reward): void {
     convertToDecimal(event.params.amount)
   );
   transcoder.lastRewardRound = round.id;
+
+  // Compute cumulative reward factor (matches on-chain PreciseMathUtils)
+  // The pool's CRF was propagated from the previous round during pool creation,
+  // so it already contains the correct previous cumulative reward factor.
+  let prevCRF = pool.cumulativeRewardFactor;
+  if (prevCRF.equals(ZERO_BI)) {
+    prevCRF = PRECISE_PERC_DIVISOR; // default: 10^27 = percPoints(1,1)
+  }
+
+  let totalRewardTokens = event.params.amount; // raw BigInt in wei
+  let transcoderCommission = percOf(totalRewardTokens, pool.rewardCut);
+  let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
+
+  let totalStakeBI = convertFromDecimal(pool.totalStake);
+  if (totalStakeBI.gt(ZERO_BI)) {
+    pool.cumulativeRewardFactor = prevCRF.plus(
+      precisePercOf(prevCRF, delegatorsRewards, totalStakeBI)
+    );
+  } else {
+    pool.cumulativeRewardFactor = prevCRF;
+  }
 
   pool.rewardTokens = convertToDecimal(event.params.amount);
   pool.feeShare = transcoder.feeShare;

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -596,11 +596,24 @@ export function reward(event: Reward): void {
   let transcoderCommission = percOf(totalRewardTokens, pool.rewardCut);
   let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
 
-  // Accumulate orchestrator reward commission
-  transcoder.pendingRewardCommission = transcoder.pendingRewardCommission.plus(transcoderCommission);
-  transcoder.lifetimeRewardCommission = transcoder.lifetimeRewardCommission.plus(transcoderCommission);
-
+  // Compute rewards earned by the transcoder's own staked commission
   let totalStakeBI = convertFromDecimal(pool.totalStake);
+  let transcoderRewardStakeRewards = ZERO_BI;
+  if (totalStakeBI.gt(ZERO_BI)) {
+    transcoderRewardStakeRewards = precisePercOf(
+      delegatorsRewards,
+      transcoder.activeCumulativeRewards,
+      totalStakeBI
+    );
+  }
+
+  // Accumulate orchestrator reward commission (rewardCut + rewards on staked commission)
+  transcoder.pendingRewardCommission = transcoder.pendingRewardCommission
+    .plus(transcoderCommission)
+    .plus(transcoderRewardStakeRewards);
+  transcoder.lifetimeRewardCommission = transcoder.lifetimeRewardCommission
+    .plus(transcoderCommission)
+    .plus(transcoderRewardStakeRewards);
   if (totalStakeBI.gt(ZERO_BI)) {
     pool.cumulativeRewardFactor = prevCRF.plus(
       precisePercOf(prevCRF, delegatorsRewards, totalStakeBI)
@@ -794,6 +807,7 @@ export function earningsClaimed(event: EarningsClaimed): void {
     );
     transcoder.pendingRewardCommission = ZERO_BI;
     transcoder.pendingFeeCommission = ZERO_BI;
+    transcoder.activeCumulativeRewards = ZERO_BI;
     transcoder.save();
   }
 

--- a/src/mappings/roundsManager.ts
+++ b/src/mappings/roundsManager.ts
@@ -128,6 +128,13 @@ export function newRound(event: NewRound): void {
     // given transcoder and round then we know the transcoder failed to call reward()
     createOrLoadPool(round.id, currentTranscoder.toHex());
 
+    if (transcoder) {
+      // Snapshot pendingRewardCommission as activeCumulativeRewards for this round,
+      // mirroring the contract's setCurrentRoundTotalActiveStake snapshot
+      transcoder.activeCumulativeRewards = transcoder.pendingRewardCommission;
+      transcoder.save();
+    }
+
     currentTranscoder =
       bondingManager.getNextTranscoderInPool(currentTranscoder);
 

--- a/src/mappings/roundsManager.ts
+++ b/src/mappings/roundsManager.ts
@@ -13,11 +13,13 @@ import {
   getBondingManagerAddress,
   getLptPriceEth,
   getTimestampForDaysPast,
+  integerFromString,
   makeEventId,
   ONE_BD,
   ONE_BI,
   PERC_DIVISOR,
   ZERO_BD,
+  ZERO_BI,
 } from "../../utils/helpers";
 import { BondingManager } from "../types/BondingManager/BondingManager";
 // Import event types from the registrar contract ABIs

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -145,6 +145,12 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   }
 
   let delegatorsFees = percOf(event.params.faceValue, pool.feeShare);
+  let transcoderFeeCommission = event.params.faceValue.minus(delegatorsFees);
+
+  // Accumulate orchestrator fee commission
+  transcoder.pendingFeeCommission = transcoder.pendingFeeCommission.plus(transcoderFeeCommission);
+  transcoder.lifetimeFeeCommission = transcoder.lifetimeFeeCommission.plus(transcoderFeeCommission);
+
   let totalStakeBI = convertFromDecimal(pool.totalStake);
   if (totalStakeBI.gt(ZERO_BI)) {
     pool.cumulativeFeeFactor = pool.cumulativeFeeFactor.plus(

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -1,5 +1,6 @@
 import { Address, BigInt, dataSource, log } from "@graphprotocol/graph-ts";
 import {
+  convertFromDecimal,
   convertToDecimal,
   createOrLoadBroadcaster,
   createOrLoadBroadcasterDay,
@@ -12,11 +13,19 @@ import {
   createOrLoadTranscoderDay,
   getBlockNum,
   getEthPriceUsd,
+  integerFromString,
   makeEventId,
+  makePoolId,
+  ONE_BI,
+  percOf,
+  PRECISE_PERC_DIVISOR,
+  precisePercOf,
   ZERO_BD,
+  ZERO_BI,
 } from "../../utils/helpers";
 import {
   DepositFundedEvent,
+  Pool,
   ReserveClaimedEvent,
   ReserveFundedEvent,
   WinningTicketRedeemedEvent,
@@ -118,8 +127,31 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   protocol.winningTicketCount = protocol.winningTicketCount + 1;
   protocol.save();
 
-  // update the transcoder pool fees
+  // update the transcoder pool fees and cumulative fee factor
   let pool = createOrLoadPool(round.id, event.params.recipient.toHex());
+
+  // Compute cumulative fee factor (matches on-chain PreciseMathUtils)
+  // Use previous round's CRF, matching contract's latestCumulativeFactorsPool(_round - 1)
+  let prevRoundNum = integerFromString(round.id).minus(ONE_BI);
+  let prevPoolForFees = Pool.load(
+    makePoolId(event.params.recipient.toHex(), prevRoundNum.toString())
+  );
+  let prevCRF = PRECISE_PERC_DIVISOR; // default: 10^27
+  if (
+    prevPoolForFees &&
+    !prevPoolForFees.cumulativeRewardFactor.equals(ZERO_BI)
+  ) {
+    prevCRF = prevPoolForFees.cumulativeRewardFactor;
+  }
+
+  let delegatorsFees = percOf(event.params.faceValue, pool.feeShare);
+  let totalStakeBI = convertFromDecimal(pool.totalStake);
+  if (totalStakeBI.gt(ZERO_BI)) {
+    pool.cumulativeFeeFactor = pool.cumulativeFeeFactor.plus(
+      precisePercOf(prevCRF, delegatorsFees, totalStakeBI)
+    );
+  }
+
   pool.fees = pool.fees.plus(faceValue);
   pool.save();
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -157,9 +157,7 @@ export function precisePercOf(
   _fracNum: BigInt,
   _fracDenom: BigInt
 ): BigInt {
-  return _baseAmount
-    .times(precisePercPoints(_fracNum, _fracDenom))
-    .div(PRECISE_PERC_DIVISOR);
+  return _baseAmount.times(_fracNum).div(_fracDenom);
 }
 
 // Convert BigDecimal (in token units) back to raw BigInt (in wei)

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -314,6 +314,7 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.sixtyDayVolumeETH = ZERO_BD;
     transcoder.ninetyDayVolumeETH = ZERO_BD;
     transcoder.transcoderDays = [];
+    transcoder.cumulativeRewards = ZERO_BI;
     transcoder.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -316,6 +316,7 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.lifetimeRewardCommission = ZERO_BI;
     transcoder.pendingFeeCommission = ZERO_BI;
     transcoder.lifetimeFeeCommission = ZERO_BI;
+    transcoder.activeCumulativeRewards = ZERO_BI;
     transcoder.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -62,22 +62,43 @@ export function createOrLoadPool(roundId: string, transcoderAddress: string): Po
     pool.delegate = transcoderAddress;
     pool.fees = ZERO_BD;
 
-    // Propagate cumulative factors from the previous round's pool so every
-    // pool has valid factors even if the transcoder misses reward() or has
-    // no fees in a round. This mirrors the contract's latestCumulativeFactorsPool.
-    let prevRoundNum = integerFromString(roundId).minus(ONE_BI);
-    let prevPool = Pool.load(
-      makePoolId(transcoderAddress, prevRoundNum.toString())
-    );
-    if (prevPool) {
-      pool.cumulativeRewardFactor = prevPool.cumulativeRewardFactor;
-      pool.cumulativeFeeFactor = prevPool.cumulativeFeeFactor;
+    let transcoder = Transcoder.load(transcoderAddress);
+
+    // Propagate cumulative factors from the most recent EXISTING pool so they
+    // never reset to base across a round gap. Normally that is the previous
+    // round's pool, but when the transcoder was inactive — or newRound's
+    // non-deterministic enumeration skipped it (see #249) — the previous
+    // round's pool can be missing for several rounds. Walk back to the most
+    // recent pool that exists, bounded below by lastRewardRound (which is
+    // guaranteed to have a pool with valid factors). This mirrors the
+    // contract's latestCumulativeFactorsPool.
+    //
+    // Only checking round-1 (the previous behavior) left the factors at 0
+    // whenever that single pool was missing, and reward() then reset the
+    // cumulative reward factor to base (10^27) — corrupting the stake of every
+    // delegator whose last claim predated the gap.
+    let sourcePool: Pool | null = null;
+    if (transcoder != null && transcoder.lastRewardRound != null) {
+      let cursor = integerFromString(roundId).minus(ONE_BI);
+      let floor = integerFromString(transcoder.lastRewardRound!);
+      while (cursor.ge(floor)) {
+        let candidate = Pool.load(
+          makePoolId(transcoderAddress, cursor.toString())
+        );
+        if (candidate != null) {
+          sourcePool = candidate;
+          break;
+        }
+        cursor = cursor.minus(ONE_BI);
+      }
+    }
+    if (sourcePool != null) {
+      pool.cumulativeRewardFactor = sourcePool.cumulativeRewardFactor;
+      pool.cumulativeFeeFactor = sourcePool.cumulativeFeeFactor;
     } else {
       pool.cumulativeRewardFactor = ZERO_BI;
       pool.cumulativeFeeFactor = ZERO_BI;
     }
-
-    let transcoder = Transcoder.load(transcoderAddress);
 
     if (transcoder) {
       pool.totalStake = transcoder.totalStake;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -315,6 +315,7 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.ninetyDayVolumeETH = ZERO_BD;
     transcoder.transcoderDays = [];
     transcoder.cumulativeRewards = ZERO_BI;
+    transcoder.lifetimeRewards = ZERO_BI;
     transcoder.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -314,8 +314,10 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.sixtyDayVolumeETH = ZERO_BD;
     transcoder.ninetyDayVolumeETH = ZERO_BD;
     transcoder.transcoderDays = [];
-    transcoder.cumulativeRewards = ZERO_BI;
-    transcoder.lifetimeRewards = ZERO_BI;
+    transcoder.pendingRewardCommission = ZERO_BI;
+    transcoder.lifetimeRewardCommission = ZERO_BI;
+    transcoder.pendingFeeCommission = ZERO_BI;
+    transcoder.lifetimeFeeCommission = ZERO_BI;
     transcoder.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -61,6 +61,22 @@ export function createOrLoadPool(roundId: string, transcoderAddress: string): Po
     pool.round = roundId;
     pool.delegate = transcoderAddress;
     pool.fees = ZERO_BD;
+
+    // Propagate cumulative factors from the previous round's pool so every
+    // pool has valid factors even if the transcoder misses reward() or has
+    // no fees in a round. This mirrors the contract's latestCumulativeFactorsPool.
+    let prevRoundNum = integerFromString(roundId).minus(ONE_BI);
+    let prevPool = Pool.load(
+      makePoolId(transcoderAddress, prevRoundNum.toString())
+    );
+    if (prevPool) {
+      pool.cumulativeRewardFactor = prevPool.cumulativeRewardFactor;
+      pool.cumulativeFeeFactor = prevPool.cumulativeFeeFactor;
+    } else {
+      pool.cumulativeRewardFactor = ZERO_BI;
+      pool.cumulativeFeeFactor = ZERO_BI;
+    }
+
     let transcoder = Transcoder.load(transcoderAddress);
 
     if (transcoder) {
@@ -122,6 +138,38 @@ export function percOf(_amount: BigInt, _fracNum: BigInt): BigInt {
 
 export function percPoints(_fracNum: BigInt, _fracDenom: BigInt): BigInt {
   return _fracNum.times(BigInt.fromI32(PERC_DIVISOR)).div(_fracDenom);
+}
+
+// PreciseMathUtils equivalents (matches Solidity's 27-decimal fixed-point arithmetic)
+export let PRECISE_PERC_DIVISOR = BigInt.fromString(
+  "1000000000000000000000000000"
+); // 10^27
+
+export function precisePercPoints(
+  _fracNum: BigInt,
+  _fracDenom: BigInt
+): BigInt {
+  return _fracNum.times(PRECISE_PERC_DIVISOR).div(_fracDenom);
+}
+
+export function precisePercOf(
+  _baseAmount: BigInt,
+  _fracNum: BigInt,
+  _fracDenom: BigInt
+): BigInt {
+  return _baseAmount
+    .times(precisePercPoints(_fracNum, _fracDenom))
+    .div(PRECISE_PERC_DIVISOR);
+}
+
+// Convert BigDecimal (in token units) back to raw BigInt (in wei)
+export function convertFromDecimal(amount: BigDecimal): BigInt {
+  let str = amount.times(exponentToBigDecimal(BI_18)).toString();
+  let dotIndex = str.indexOf(".");
+  if (dotIndex >= 0) {
+    str = str.substring(0, dotIndex);
+  }
+  return BigInt.fromString(str);
 }
 
 export function exponentToBigDecimal(decimals: BigInt): BigDecimal {
@@ -287,6 +335,7 @@ export function createOrLoadDelegator(id: string, timestamp: i32): Delegator {
     delegator.fees = ZERO_BD;
     delegator.withdrawnFees = ZERO_BD;
     delegator.delegatedAmount = ZERO_BD;
+    delegator.shares = ZERO_BI;
     delegator.save();
   }
 


### PR DESCRIPTION
## Problem

The subgraph has no way to compute a delegator's actual total stake. The `bondedAmount` field only reflects the value at the time of the last claim and does not include rewards earned since then. To get a delegator's current stake, clients must call the contract's `pendingStake()` method directly — and for historical stake at a past round, there is no solution at all.

Similarly, computing an orchestrator's full pending stake (including their unclaimed commission) or their lifetime earnings requires fetching every pool since their last claim and summing across all of them.

This also means there's no way to build time-series charts of delegator stake, show per-round reward breakdowns, or compute orchestrator yield — all of which require knowing stake values across rounds.

## Summary

- Store `cumulativeRewardFactor` and `cumulativeFeeFactor` on the `Pool` entity, matching on-chain PreciseMathUtils (27-decimal fixed-point)
- Propagate cumulative factors forward each round during pool creation so every pool has valid values (no gaps for missed `reward()` calls)
- Add `shares` field to `Delegator` (`bondedAmount * 10^27 / crf[lastClaimRound]`) — invariant across claims, only changes on bond/unbond/rebond
- Add `DelegatorSnapshot` entity capturing delegator state at each bond/unbond/rebond for time-series chart support
- Compute cumulative fee factor in `WinningTicketRedeemed` handler using previous round's CRF (matching contract behavior)
- Add orchestrator commission tracking on `Transcoder`:
  - `pendingRewardCommission` — unclaimed reward commission (rewardCut portion), resets on claim
  - `lifetimeRewardCommission` — total reward commission ever earned, never resets
  - `pendingFeeCommission` — unclaimed fee commission, resets on claim
  - `lifetimeFeeCommission` — total fee commission ever earned, never resets

## What this unlocks

**Current pending stake without contract calls** — A delegator's up-to-date total stake (equivalent to `pendingStake()` on-chain) can now be computed entirely from the subgraph: `stake = shares * crf / 10^27`. For orchestrators specifically, their full pending stake includes unclaimed commission: `stake = shares * crf / 10^27 + pendingRewardCommission`. No contract calls needed.

**Historical stake at any past round** — Something previously impossible. Query the delegator's shares (or the relevant `DelegatorSnapshot`) and the `Pool.cumulativeRewardFactor` for that round, then compute `shares * crf[round] / 10^27`.

**Per-round reward and fee breakdowns** — Rewards earned in a specific round can be derived by comparing cumulative factors between consecutive rounds: `rewards = shares * (crf[round] - crf[round-1]) / 10^27`. Same pattern applies to fees using `cumulativeFeeFactor`.

**Time-series charts of delegator stake** — The `shares` approach combined with `DelegatorSnapshot` entities makes it straightforward to build a chart showing a delegator's total stake over time. Between snapshots, shares are constant, so stake at any round is just `shares * crf[round] / 10^27`. When a bond/unbond/rebond occurs, a new snapshot captures the updated shares value to use going forward.

> **Live example:** [livepeer-portfolio-manager.vercel.app](https://livepeer-portfolio-manager.vercel.app/) is a dashboard built entirely on this data. It charts total delegated stake over time across multiple delegator accounts — plus per-round rewards and network-equity share — using the per-round `cumulativeRewardFactor` values this PR adds, with no contract calls. Its total pending stake was verified to match on-chain `BondingManager.pendingStake()` exactly.

**Orchestrator commission tracking** — `pendingRewardCommission` and `pendingFeeCommission` give the orchestrator's unclaimed commission in a single field each, without needing to sum across pools. `lifetimeRewardCommission` and `lifetimeFeeCommission` provide total lifetime earnings.

**Orchestrator pool analytics** — Cumulative factors stored per-pool per-round enable computing total rewards distributed, effective yield, and fee revenue for any orchestrator over any time range without replaying events.

All changes are additive — no breaking changes to existing queries.

## Test plan

- [x] Run `npx graph codegen && npx graph build` — verified locally
- [x] Deploy to a staging subgraph and verify cumulative factors match on-chain values
- [x] Verify delegator shares remain constant across claim events
- [x] Verify `shares * crf[round] / 10^27` matches actual bonded amounts
- [x] Verify pending stake computed from subgraph matches contract `pendingStake()` return value
- [x] Verify DelegatorSnapshot entities are created on bond/unbond/rebond but not on claim
- [x] Verify `pendingRewardCommission` and `pendingFeeCommission` reset to zero after orchestrator claims
- [x] Verify `lifetimeRewardCommission` and `lifetimeFeeCommission` never reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed transcoder commission and cumulative reward/fee data to the GraphQL API.
  * Added delegator share tracking and historical snapshots for state-changing events.
  * Improved reward and fee calculations using cumulative factors, supporting more efficient delegator accounting.
  * Added historical commission tracking and automatic updates during rewards, claims, and ticket redemption.
  * Initialized new accounting fields consistently for pools, transcoders, and delegators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
