### PR TITLE
feat: add cumulative reward/fee factors, delegator shares, and orchestrator commission tracking

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -108,6 +108,8 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
+  "Lifetime cumulative rewards (rewardCut commission) earned by this orchestrator in wei"
+  cumulativeRewards: BigInt!
 }
 
 enum TranscoderStatus @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -108,10 +108,12 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
-  "Unclaimed orchestrator reward commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + pendingRewardCommission"
+  "Unclaimed orchestrator reward commission in wei. Includes both rewardCut commission and rewards earned on staked commission. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + pendingRewardCommission"
   pendingRewardCommission: BigInt!
-  "Lifetime total orchestrator reward commission earned (rewardCut portion) in wei. Never resets."
+  "Lifetime total orchestrator reward commission earned in wei. Never resets."
   lifetimeRewardCommission: BigInt!
+  "Snapshot of pendingRewardCommission at the start of the current round. Used to compute the transcoder's share of delegator rewards earned by its own staked commission. Resets to zero on claim."
+  activeCumulativeRewards: BigInt!
   "Unclaimed orchestrator fee commission in wei. Resets to zero on claim."
   pendingFeeCommission: BigInt!
   "Lifetime total orchestrator fee commission earned in wei. Never resets."

--- a/schema.graphql
+++ b/schema.graphql
@@ -108,7 +108,7 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
-  "Lifetime cumulative rewards (rewardCut commission) earned by this orchestrator in wei"
+  "Unclaimed orchestrator commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + cumulativeRewards"
   cumulativeRewards: BigInt!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -78,6 +78,8 @@ type Transcoder @entity {
   activationTimestamp: Int!
   "Last round that the transcoder called reward"
   lastRewardRound: Round
+  "Last round that the transcoder received fees"
+  lastFeeRound: Round
   "% of block reward cut paid to transcoder by a delegator"
   rewardCut: BigInt!
   "The last timestamped update to reward cut, beginning at 12:00am UTC"
@@ -108,11 +110,11 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
-  "Unclaimed orchestrator reward commission in wei. Includes both rewardCut commission and rewards earned on staked commission. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + pendingRewardCommission"
+  "Unclaimed orchestrator reward commission in wei. Includes both rewardCut commission and compounding rewards earned on staked commission. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + pendingRewardCommission"
   pendingRewardCommission: BigInt!
   "Lifetime total orchestrator reward commission earned in wei. Never resets."
   lifetimeRewardCommission: BigInt!
-  "Snapshot of pendingRewardCommission at the start of the current round. Used to compute the transcoder's share of delegator rewards earned by its own staked commission. Resets to zero on claim."
+  "Snapshot of pendingRewardCommission taken at reward() call time (re-snapshotted from initial round-start value). Used to compute the transcoder's share of delegator rewards/fees earned by its own staked commission. Not reset on claim; the reward handler re-snapshots it."
   activeCumulativeRewards: BigInt!
   "Unclaimed orchestrator fee commission in wei. Resets to zero on claim."
   pendingFeeCommission: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -108,10 +108,14 @@ type Transcoder @entity {
   serviceURI: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
-  "Unclaimed orchestrator commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + cumulativeRewards"
-  cumulativeRewards: BigInt!
-  "Lifetime total orchestrator commission earned (rewardCut portion) in wei. Never resets."
-  lifetimeRewards: BigInt!
+  "Unclaimed orchestrator reward commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + pendingRewardCommission"
+  pendingRewardCommission: BigInt!
+  "Lifetime total orchestrator reward commission earned (rewardCut portion) in wei. Never resets."
+  lifetimeRewardCommission: BigInt!
+  "Unclaimed orchestrator fee commission in wei. Resets to zero on claim."
+  pendingFeeCommission: BigInt!
+  "Lifetime total orchestrator fee commission earned in wei. Never resets."
+  lifetimeFeeCommission: BigInt!
 }
 
 enum TranscoderStatus @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -110,6 +110,8 @@ type Transcoder @entity {
   transcoderDays: [TranscoderDay!]!
   "Unclaimed orchestrator commission (rewardCut portion) in wei. Resets to zero on claim. Full pending stake = shares * crf / 10^27 + cumulativeRewards"
   cumulativeRewards: BigInt!
+  "Lifetime total orchestrator commission earned (rewardCut portion) in wei. Never resets."
+  lifetimeRewards: BigInt!
 }
 
 enum TranscoderStatus @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -135,6 +135,10 @@ type Pool @entity {
   rewardCut: BigInt!
   "Transcoder's fee share during the earnings pool's round"
   feeShare: BigInt!
+  "Cumulative reward factor for computing delegator rewards without looping (27-decimal fixed-point, matches on-chain PreciseMathUtils)"
+  cumulativeRewardFactor: BigInt!
+  "Cumulative fee factor for computing delegator fees without looping (27-decimal fixed-point, matches on-chain PreciseMathUtils)"
+  cumulativeFeeFactor: BigInt!
 }
 
 """
@@ -205,8 +209,30 @@ type Delegator @entity {
   withdrawnFees: BigDecimal!
   "Amount of Livepeer Token the delegator has delegated"
   delegatedAmount: BigDecimal!
+  "Proportional claim on the orchestrator's pool (bondedAmount * 10^27 / crf[lastClaimRound]). Invariant across claims, only changes on bond/unbond."
+  shares: BigInt!
   "Unbonding locks associated with the delegator"
   unbondingLocks: [UnbondingLock!] @derivedFrom(field: "delegator")
+}
+
+"""
+Snapshot of delegator state at each state-changing event, enabling historical stake and reward computation via cumulative factors
+"""
+type DelegatorSnapshot @entity {
+  "Unique identifier: delegator address + round number"
+  id: ID!
+  "The delegator this snapshot belongs to"
+  delegator: Delegator!
+  "The delegate (orchestrator) at the time of this snapshot, null if fully unbonded"
+  delegate: Transcoder
+  "Bonded amount at the time of this snapshot"
+  bondedAmount: BigDecimal!
+  "Proportional claim on the orchestrator's pool. stake = shares * crf[round] / 10^27"
+  shares: BigInt!
+  "Round when this snapshot was taken"
+  round: Round!
+  "Timestamp when this snapshot was taken"
+  timestamp: Int!
 }
 
 """

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -596,11 +596,24 @@ export function reward(event: Reward): void {
   let transcoderCommission = percOf(totalRewardTokens, pool!.rewardCut);
   let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
 
-  // Accumulate orchestrator reward commission
-  transcoder.pendingRewardCommission = transcoder.pendingRewardCommission.plus(transcoderCommission);
-  transcoder.lifetimeRewardCommission = transcoder.lifetimeRewardCommission.plus(transcoderCommission);
-
+  // Compute rewards earned by the transcoder's own staked commission
   let totalStakeBI = convertFromDecimal(pool!.totalStake);
+  let transcoderRewardStakeRewards = ZERO_BI;
+  if (totalStakeBI.gt(ZERO_BI)) {
+    transcoderRewardStakeRewards = precisePercOf(
+      delegatorsRewards,
+      transcoder.activeCumulativeRewards,
+      totalStakeBI
+    );
+  }
+
+  // Accumulate orchestrator reward commission (rewardCut + rewards on staked commission)
+  transcoder.pendingRewardCommission = transcoder.pendingRewardCommission
+    .plus(transcoderCommission)
+    .plus(transcoderRewardStakeRewards);
+  transcoder.lifetimeRewardCommission = transcoder.lifetimeRewardCommission
+    .plus(transcoderCommission)
+    .plus(transcoderRewardStakeRewards);
   if (totalStakeBI.gt(ZERO_BI)) {
     pool!.cumulativeRewardFactor = prevCRF.plus(
       precisePercOf(prevCRF, delegatorsRewards, totalStakeBI)
@@ -794,6 +807,7 @@ export function earningsClaimed(event: EarningsClaimed): void {
     );
     transcoder.pendingRewardCommission = ZERO_BI;
     transcoder.pendingFeeCommission = ZERO_BI;
+    transcoder.activeCumulativeRewards = ZERO_BI;
     transcoder.save();
   }
 

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -1,4 +1,4 @@
-import { store } from "@graphprotocol/graph-ts";
+import { BigInt, store } from "@graphprotocol/graph-ts";
 import {
   convertFromDecimal,
   convertToDecimal,
@@ -38,6 +38,7 @@ import {
 } from "../types/BondingManager/BondingManager";
 import {
   BondEvent,
+  Delegator,
   DelegatorSnapshot,
   EarningsClaimedEvent,
   ParameterUpdateEvent,
@@ -54,6 +55,37 @@ import {
   WithdrawFeesEvent,
   WithdrawStakeEvent,
 } from "../types/schema";
+
+// Save a point-in-time record of delegator state for historical queries
+function saveDelegatorSnapshot(
+  delegatorAddress: string,
+  delegate: string,
+  delegator: Delegator,
+  roundId: string,
+  timestamp: i32
+): void {
+  let snapshot = new DelegatorSnapshot(delegatorAddress + "-" + roundId);
+  snapshot.delegator = delegatorAddress;
+  snapshot.delegate = delegate;
+  snapshot.bondedAmount = delegator.bondedAmount;
+  snapshot.shares = delegator.shares;
+  snapshot.round = roundId;
+  snapshot.timestamp = timestamp;
+  snapshot.save();
+}
+
+// Compute delegator shares: bondedAmount * 10^27 / CRF[currentRound]
+function computeShares(delegate: string, roundId: string, bondedAmount: BigInt): BigInt {
+  if (bondedAmount.isZero()) {
+    return ZERO_BI;
+  }
+  let pool = Pool.load(makePoolId(delegate, roundId));
+  let crf = PRECISE_PERC_DIVISOR;
+  if (pool && !pool.cumulativeRewardFactor.equals(ZERO_BI)) {
+    crf = pool.cumulativeRewardFactor;
+  }
+  return bondedAmount.times(PRECISE_PERC_DIVISOR).div(crf);
+}
 
 export function bond(event: Bond): void {
   let bondingManager = BondingManager.bind(event.address);
@@ -140,21 +172,11 @@ export function bond(event: Bond): void {
     convertToDecimal(event.params.additionalAmount)
   );
 
-  // Compute shares: bondedAmount * 10^27 / crf[lastClaimRound]
-  // shares is invariant across claims, only changes on bond/unbond
-  let poolForShares = Pool.load(
-    makePoolId(event.params.newDelegate.toHex(), round.id)
+  delegator.shares = computeShares(
+    event.params.newDelegate.toHex(),
+    round.id,
+    event.params.bondedAmount
   );
-  let sharesRefCRF = PRECISE_PERC_DIVISOR;
-  if (
-    poolForShares &&
-    !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
-  ) {
-    sharesRefCRF = poolForShares.cumulativeRewardFactor;
-  }
-  delegator.shares = event.params.bondedAmount
-    .times(PRECISE_PERC_DIVISOR)
-    .div(sharesRefCRF);
 
   round.save();
   delegate.save();
@@ -162,16 +184,13 @@ export function bond(event: Bond): void {
   transcoder.save();
   protocol.save();
 
-  // Save delegator snapshot for historical stake/reward computation
-  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
-  let snapshot = new DelegatorSnapshot(snapshotId);
-  snapshot.delegator = event.params.delegator.toHex();
-  snapshot.delegate = event.params.newDelegate.toHex();
-  snapshot.bondedAmount = delegator.bondedAmount;
-  snapshot.shares = delegator.shares;
-  snapshot.round = round.id;
-  snapshot.timestamp = event.block.timestamp.toI32();
-  snapshot.save();
+  saveDelegatorSnapshot(
+    event.params.delegator.toHex(),
+    event.params.newDelegate.toHex(),
+    delegator,
+    round.id,
+    event.block.timestamp.toI32()
+  );
 
   createOrLoadTransactionFromEvent(event);
 
@@ -292,24 +311,11 @@ export function unbond(event: Unbond): void {
     convertToDecimal(event.params.amount)
   );
 
-  // Compute shares from new bonded amount
-  if (delegatorData.value0.isZero()) {
-    delegator.shares = ZERO_BI;
-  } else {
-    let poolForShares = Pool.load(
-      makePoolId(event.params.delegate.toHex(), round.id)
-    );
-    let sharesRefCRF = PRECISE_PERC_DIVISOR;
-    if (
-      poolForShares &&
-      !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
-    ) {
-      sharesRefCRF = poolForShares.cumulativeRewardFactor;
-    }
-    delegator.shares = delegatorData.value0
-      .times(PRECISE_PERC_DIVISOR)
-      .div(sharesRefCRF);
-  }
+  delegator.shares = computeShares(
+    event.params.delegate.toHex(),
+    round.id,
+    delegatorData.value0
+  );
 
   // Delegator no longer delegated to anyone if it does not have a bonded amount
   // so remove it from delegate
@@ -343,16 +349,13 @@ export function unbond(event: Unbond): void {
   protocol.save();
   round.save();
 
-  // Save delegator snapshot for historical stake/reward computation
-  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
-  let snapshot = new DelegatorSnapshot(snapshotId);
-  snapshot.delegator = event.params.delegator.toHex();
-  snapshot.delegate = delegator.delegate;
-  snapshot.bondedAmount = delegator.bondedAmount;
-  snapshot.shares = delegator.shares;
-  snapshot.round = round.id;
-  snapshot.timestamp = event.block.timestamp.toI32();
-  snapshot.save();
+  saveDelegatorSnapshot(
+    event.params.delegator.toHex(),
+    delegator.delegate ? delegator.delegate! : "",
+    delegator,
+    round.id,
+    event.block.timestamp.toI32()
+  );
 
   createOrLoadTransactionFromEvent(event);
 
@@ -414,20 +417,11 @@ export function rebond(event: Rebond): void {
   delegator.bondedAmount = convertToDecimal(delegatorData.value0);
   delegator.fees = convertToDecimal(delegatorData.value1);
 
-  // Compute shares: bondedAmount * 10^27 / crf[lastClaimRound]
-  let poolForShares = Pool.load(
-    makePoolId(event.params.delegate.toHex(), round.id)
+  delegator.shares = computeShares(
+    event.params.delegate.toHex(),
+    round.id,
+    delegatorData.value0
   );
-  let sharesRefCRF = PRECISE_PERC_DIVISOR;
-  if (
-    poolForShares &&
-    !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
-  ) {
-    sharesRefCRF = poolForShares.cumulativeRewardFactor;
-  }
-  delegator.shares = delegatorData.value0
-    .times(PRECISE_PERC_DIVISOR)
-    .div(sharesRefCRF);
 
   // If the sender field for the lock is equal to the delegator's address then
   // we know that this is an unbonding lock the delegator created by calling
@@ -449,16 +443,13 @@ export function rebond(event: Rebond): void {
   delegator.save();
   protocol.save();
 
-  // Save delegator snapshot for historical stake/reward computation
-  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
-  let snapshot = new DelegatorSnapshot(snapshotId);
-  snapshot.delegator = event.params.delegator.toHex();
-  snapshot.delegate = event.params.delegate.toHex();
-  snapshot.bondedAmount = delegator.bondedAmount;
-  snapshot.shares = delegator.shares;
-  snapshot.round = round.id;
-  snapshot.timestamp = event.block.timestamp.toI32();
-  snapshot.save();
+  saveDelegatorSnapshot(
+    event.params.delegator.toHex(),
+    event.params.delegate.toHex(),
+    delegator,
+    round.id,
+    event.block.timestamp.toI32()
+  );
 
   if (unbondingLock) {
     store.remove("UnbondingLock", uniqueUnbondingLockId);

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -596,9 +596,9 @@ export function reward(event: Reward): void {
   let transcoderCommission = percOf(totalRewardTokens, pool!.rewardCut);
   let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
 
-  // Accumulate orchestrator commission
-  transcoder.cumulativeRewards = transcoder.cumulativeRewards.plus(transcoderCommission);
-  transcoder.lifetimeRewards = transcoder.lifetimeRewards.plus(transcoderCommission);
+  // Accumulate orchestrator reward commission
+  transcoder.pendingRewardCommission = transcoder.pendingRewardCommission.plus(transcoderCommission);
+  transcoder.lifetimeRewardCommission = transcoder.lifetimeRewardCommission.plus(transcoderCommission);
 
   let totalStakeBI = convertFromDecimal(pool!.totalStake);
   if (totalStakeBI.gt(ZERO_BI)) {
@@ -792,7 +792,8 @@ export function earningsClaimed(event: EarningsClaimed): void {
       event.params.delegator.toHex(),
       event.block.timestamp.toI32()
     );
-    transcoder.cumulativeRewards = ZERO_BI;
+    transcoder.pendingRewardCommission = ZERO_BI;
+    transcoder.pendingFeeCommission = ZERO_BI;
     transcoder.save();
   }
 

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -596,8 +596,9 @@ export function reward(event: Reward): void {
   let transcoderCommission = percOf(totalRewardTokens, pool!.rewardCut);
   let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
 
-  // Accumulate lifetime orchestrator commission
+  // Accumulate orchestrator commission
   transcoder.cumulativeRewards = transcoder.cumulativeRewards.plus(transcoderCommission);
+  transcoder.lifetimeRewards = transcoder.lifetimeRewards.plus(transcoderCommission);
 
   let totalStakeBI = convertFromDecimal(pool!.totalStake);
   if (totalStakeBI.gt(ZERO_BI)) {

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -1,5 +1,6 @@
-import { BigInt, store } from "@graphprotocol/graph-ts";
+import { store } from "@graphprotocol/graph-ts";
 import {
+  computeShares,
   convertFromDecimal,
   convertToDecimal,
   createOrLoadDelegator,
@@ -17,6 +18,7 @@ import {
   percOf,
   PRECISE_PERC_DIVISOR,
   precisePercOf,
+  saveDelegatorSnapshot,
   ZERO_BI,
 } from "../../utils/helpers";
 // Import event types from the registrar contract ABIs
@@ -38,8 +40,6 @@ import {
 } from "../types/BondingManager/BondingManager";
 import {
   BondEvent,
-  Delegator,
-  DelegatorSnapshot,
   EarningsClaimedEvent,
   ParameterUpdateEvent,
   Pool,
@@ -55,37 +55,6 @@ import {
   WithdrawFeesEvent,
   WithdrawStakeEvent,
 } from "../types/schema";
-
-// Save a point-in-time record of delegator state for historical queries
-function saveDelegatorSnapshot(
-  delegatorAddress: string,
-  delegate: string,
-  delegator: Delegator,
-  roundId: string,
-  timestamp: i32
-): void {
-  let snapshot = new DelegatorSnapshot(delegatorAddress + "-" + roundId);
-  snapshot.delegator = delegatorAddress;
-  snapshot.delegate = delegate;
-  snapshot.bondedAmount = delegator.bondedAmount;
-  snapshot.shares = delegator.shares;
-  snapshot.round = roundId;
-  snapshot.timestamp = timestamp;
-  snapshot.save();
-}
-
-// Compute delegator shares: bondedAmount * 10^27 / CRF[currentRound]
-function computeShares(delegate: string, roundId: string, bondedAmount: BigInt): BigInt {
-  if (bondedAmount.isZero()) {
-    return ZERO_BI;
-  }
-  let pool = Pool.load(makePoolId(delegate, roundId));
-  let crf = PRECISE_PERC_DIVISOR;
-  if (pool && !pool.cumulativeRewardFactor.equals(ZERO_BI)) {
-    crf = pool.cumulativeRewardFactor;
-  }
-  return bondedAmount.times(PRECISE_PERC_DIVISOR).div(crf);
-}
 
 export function bond(event: Bond): void {
   let bondingManager = BondingManager.bind(event.address);

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -575,6 +575,11 @@ export function reward(event: Reward): void {
   );
   transcoder.lastRewardRound = round.id;
 
+  // Snapshot activeCumulativeRewards from pendingRewardCommission, mirroring
+  // the contract's updateTranscoderWithRewards (line 1490):
+  // t.activeCumulativeRewards = t.cumulativeRewards
+  transcoder.activeCumulativeRewards = transcoder.pendingRewardCommission;
+
   // Compute cumulative reward factor (matches on-chain PreciseMathUtils)
   // The pool's CRF was propagated from the previous round during pool creation,
   // so it already contains the correct previous cumulative reward factor.
@@ -584,8 +589,8 @@ export function reward(event: Reward): void {
   }
 
   let totalRewardTokens = event.params.amount; // raw BigInt in wei
-  let transcoderCommission = percOf(totalRewardTokens, pool!.rewardCut);
-  let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
+  let transcoderCommissionRewards = percOf(totalRewardTokens, pool!.rewardCut);
+  let delegatorsRewards = totalRewardTokens.minus(transcoderCommissionRewards);
 
   // Compute rewards earned by the transcoder's own staked commission
   let totalStakeBI = convertFromDecimal(pool!.totalStake);
@@ -600,10 +605,10 @@ export function reward(event: Reward): void {
 
   // Accumulate orchestrator reward commission (rewardCut + rewards on staked commission)
   transcoder.pendingRewardCommission = transcoder.pendingRewardCommission
-    .plus(transcoderCommission)
+    .plus(transcoderCommissionRewards)
     .plus(transcoderRewardStakeRewards);
   transcoder.lifetimeRewardCommission = transcoder.lifetimeRewardCommission
-    .plus(transcoderCommission)
+    .plus(transcoderCommissionRewards)
     .plus(transcoderRewardStakeRewards);
   if (totalStakeBI.gt(ZERO_BI)) {
     pool!.cumulativeRewardFactor = prevCRF.plus(
@@ -798,7 +803,9 @@ export function earningsClaimed(event: EarningsClaimed): void {
     );
     transcoder.pendingRewardCommission = ZERO_BI;
     transcoder.pendingFeeCommission = ZERO_BI;
-    transcoder.activeCumulativeRewards = ZERO_BI;
+    // activeCumulativeRewards is NOT reset here — the contract preserves it
+    // until the next reward() call. The claimed commission stays in totalStake
+    // (as regular bondedAmount) and should still earn its share of fees.
     transcoder.save();
   }
 

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -596,6 +596,9 @@ export function reward(event: Reward): void {
   let transcoderCommission = percOf(totalRewardTokens, pool!.rewardCut);
   let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
 
+  // Accumulate lifetime orchestrator commission
+  transcoder.cumulativeRewards = transcoder.cumulativeRewards.plus(transcoderCommission);
+
   let totalStakeBI = convertFromDecimal(pool!.totalStake);
   if (totalStakeBI.gt(ZERO_BI)) {
     pool!.cumulativeRewardFactor = prevCRF.plus(

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -785,6 +785,16 @@ export function earningsClaimed(event: EarningsClaimed): void {
   delegator.fees = delegator.fees.plus(convertToDecimal(event.params.fees));
   delegator.save();
 
+  // Reset orchestrator's unclaimed commission when they claim
+  if (event.params.delegator.toHex() == event.params.delegate.toHex()) {
+    let transcoder = createOrLoadTranscoder(
+      event.params.delegator.toHex(),
+      event.block.timestamp.toI32()
+    );
+    transcoder.cumulativeRewards = ZERO_BI;
+    transcoder.save();
+  }
+
   createOrLoadTransactionFromEvent(event);
 
   let earningsClaimedEvent = new EarningsClaimedEvent(

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -1,5 +1,6 @@
 import { store } from "@graphprotocol/graph-ts";
 import {
+  convertFromDecimal,
   convertToDecimal,
   createOrLoadDelegator,
   createOrLoadProtocol,
@@ -13,6 +14,9 @@ import {
   makeUnbondingLockId,
   MAXIMUM_VALUE_UINT256,
   ONE_BI,
+  percOf,
+  PRECISE_PERC_DIVISOR,
+  precisePercOf,
   ZERO_BI,
 } from "../../utils/helpers";
 // Import event types from the registrar contract ABIs
@@ -34,6 +38,7 @@ import {
 } from "../types/BondingManager/BondingManager";
 import {
   BondEvent,
+  DelegatorSnapshot,
   EarningsClaimedEvent,
   ParameterUpdateEvent,
   Pool,
@@ -135,11 +140,38 @@ export function bond(event: Bond): void {
     convertToDecimal(event.params.additionalAmount)
   );
 
+  // Compute shares: bondedAmount * 10^27 / crf[lastClaimRound]
+  // shares is invariant across claims, only changes on bond/unbond
+  let poolForShares = Pool.load(
+    makePoolId(event.params.newDelegate.toHex(), round.id)
+  );
+  let sharesRefCRF = PRECISE_PERC_DIVISOR;
+  if (
+    poolForShares &&
+    !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
+  ) {
+    sharesRefCRF = poolForShares.cumulativeRewardFactor;
+  }
+  delegator.shares = event.params.bondedAmount
+    .times(PRECISE_PERC_DIVISOR)
+    .div(sharesRefCRF);
+
   round.save();
   delegate.save();
   delegator.save();
   transcoder.save();
   protocol.save();
+
+  // Save delegator snapshot for historical stake/reward computation
+  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
+  let snapshot = new DelegatorSnapshot(snapshotId);
+  snapshot.delegator = event.params.delegator.toHex();
+  snapshot.delegate = event.params.newDelegate.toHex();
+  snapshot.bondedAmount = delegator.bondedAmount;
+  snapshot.shares = delegator.shares;
+  snapshot.round = round.id;
+  snapshot.timestamp = event.block.timestamp.toI32();
+  snapshot.save();
 
   createOrLoadTransactionFromEvent(event);
 
@@ -260,6 +292,25 @@ export function unbond(event: Unbond): void {
     convertToDecimal(event.params.amount)
   );
 
+  // Compute shares from new bonded amount
+  if (delegatorData.value0.isZero()) {
+    delegator.shares = ZERO_BI;
+  } else {
+    let poolForShares = Pool.load(
+      makePoolId(event.params.delegate.toHex(), round.id)
+    );
+    let sharesRefCRF = PRECISE_PERC_DIVISOR;
+    if (
+      poolForShares &&
+      !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
+    ) {
+      sharesRefCRF = poolForShares.cumulativeRewardFactor;
+    }
+    delegator.shares = delegatorData.value0
+      .times(PRECISE_PERC_DIVISOR)
+      .div(sharesRefCRF);
+  }
+
   // Delegator no longer delegated to anyone if it does not have a bonded amount
   // so remove it from delegate
   if (delegatorData.value0.isZero()) {
@@ -291,6 +342,17 @@ export function unbond(event: Unbond): void {
   delegator.save();
   protocol.save();
   round.save();
+
+  // Save delegator snapshot for historical stake/reward computation
+  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
+  let snapshot = new DelegatorSnapshot(snapshotId);
+  snapshot.delegator = event.params.delegator.toHex();
+  snapshot.delegate = delegator.delegate;
+  snapshot.bondedAmount = delegator.bondedAmount;
+  snapshot.shares = delegator.shares;
+  snapshot.round = round.id;
+  snapshot.timestamp = event.block.timestamp.toI32();
+  snapshot.save();
 
   createOrLoadTransactionFromEvent(event);
 
@@ -352,6 +414,21 @@ export function rebond(event: Rebond): void {
   delegator.bondedAmount = convertToDecimal(delegatorData.value0);
   delegator.fees = convertToDecimal(delegatorData.value1);
 
+  // Compute shares: bondedAmount * 10^27 / crf[lastClaimRound]
+  let poolForShares = Pool.load(
+    makePoolId(event.params.delegate.toHex(), round.id)
+  );
+  let sharesRefCRF = PRECISE_PERC_DIVISOR;
+  if (
+    poolForShares &&
+    !poolForShares.cumulativeRewardFactor.equals(ZERO_BI)
+  ) {
+    sharesRefCRF = poolForShares.cumulativeRewardFactor;
+  }
+  delegator.shares = delegatorData.value0
+    .times(PRECISE_PERC_DIVISOR)
+    .div(sharesRefCRF);
+
   // If the sender field for the lock is equal to the delegator's address then
   // we know that this is an unbonding lock the delegator created by calling
   // unbond() and if it is not then we know that this is an unbonding lock created
@@ -371,6 +448,17 @@ export function rebond(event: Rebond): void {
   transcoder.save();
   delegator.save();
   protocol.save();
+
+  // Save delegator snapshot for historical stake/reward computation
+  let snapshotId = event.params.delegator.toHex() + "-" + round.id;
+  let snapshot = new DelegatorSnapshot(snapshotId);
+  snapshot.delegator = event.params.delegator.toHex();
+  snapshot.delegate = event.params.delegate.toHex();
+  snapshot.bondedAmount = delegator.bondedAmount;
+  snapshot.shares = delegator.shares;
+  snapshot.round = round.id;
+  snapshot.timestamp = event.block.timestamp.toI32();
+  snapshot.save();
 
   if (unbondingLock) {
     store.remove("UnbondingLock", uniqueUnbondingLockId);
@@ -495,6 +583,27 @@ export function reward(event: Reward): void {
     convertToDecimal(event.params.amount)
   );
   transcoder.lastRewardRound = round.id;
+
+  // Compute cumulative reward factor (matches on-chain PreciseMathUtils)
+  // The pool's CRF was propagated from the previous round during pool creation,
+  // so it already contains the correct previous cumulative reward factor.
+  let prevCRF = pool!.cumulativeRewardFactor;
+  if (prevCRF.equals(ZERO_BI)) {
+    prevCRF = PRECISE_PERC_DIVISOR; // default: 10^27 = percPoints(1,1)
+  }
+
+  let totalRewardTokens = event.params.amount; // raw BigInt in wei
+  let transcoderCommission = percOf(totalRewardTokens, pool!.rewardCut);
+  let delegatorsRewards = totalRewardTokens.minus(transcoderCommission);
+
+  let totalStakeBI = convertFromDecimal(pool!.totalStake);
+  if (totalStakeBI.gt(ZERO_BI)) {
+    pool!.cumulativeRewardFactor = prevCRF.plus(
+      precisePercOf(prevCRF, delegatorsRewards, totalStakeBI)
+    );
+  } else {
+    pool!.cumulativeRewardFactor = prevCRF;
+  }
 
   pool!.rewardTokens = convertToDecimal(event.params.amount);
   pool!.feeShare = transcoder.feeShare;

--- a/src/mappings/roundsManager.ts
+++ b/src/mappings/roundsManager.ts
@@ -12,12 +12,14 @@ import {
   getBondingManagerAddress,
   getLptPriceEth,
   getTimestampForDaysPast,
+  integerFromString,
   makeEventId,
   makePoolId,
   ONE_BD,
   ONE_BI,
   PERC_DIVISOR,
   ZERO_BD,
+  ZERO_BI,
 } from "../../utils/helpers";
 import { BondingManager } from "../types/BondingManager/BondingManager";
 // Import event types from the registrar contract ABIs
@@ -132,6 +134,24 @@ export function newRound(event: NewRound): void {
     pool.round = round.id;
     pool.delegate = currentTranscoder.toHex();
     pool.fees = ZERO_BD;
+
+    // Propagate cumulative factors from the previous round's pool so every
+    // pool has valid factors even if the transcoder misses reward() or has
+    // no fees in a round. This mirrors the contract's latestCumulativeFactorsPool.
+    let prevRoundNum = integerFromString(round.id).minus(ONE_BI);
+    let prevPoolId = makePoolId(
+      currentTranscoder.toHex(),
+      prevRoundNum.toString()
+    );
+    let prevPool = Pool.load(prevPoolId);
+    if (prevPool) {
+      pool.cumulativeRewardFactor = prevPool.cumulativeRewardFactor;
+      pool.cumulativeFeeFactor = prevPool.cumulativeFeeFactor;
+    } else {
+      pool.cumulativeRewardFactor = ZERO_BI;
+      pool.cumulativeFeeFactor = ZERO_BI;
+    }
+
     if (transcoder) {
       pool.totalStake = transcoder.totalStake;
       pool.rewardCut = transcoder.rewardCut;

--- a/src/mappings/roundsManager.ts
+++ b/src/mappings/roundsManager.ts
@@ -156,6 +156,11 @@ export function newRound(event: NewRound): void {
       pool.totalStake = transcoder.totalStake;
       pool.rewardCut = transcoder.rewardCut;
       pool.feeShare = transcoder.feeShare;
+
+      // Snapshot pendingRewardCommission as activeCumulativeRewards for this round,
+      // mirroring the contract's setCurrentRoundTotalActiveStake snapshot
+      transcoder.activeCumulativeRewards = transcoder.pendingRewardCommission;
+      transcoder.save();
     }
     pool.save();
 

--- a/src/mappings/roundsManager.ts
+++ b/src/mappings/roundsManager.ts
@@ -138,22 +138,35 @@ export function newRound(event: NewRound): void {
     // Ensure every pool has valid cumulative factors even when reward() is
     // missed or no fees are earned. Mirrors the contract's
     // latestCumulativeFactorsPool(): try the previous round, fall back to
-    // lastRewardRound if the transcoder was inactive.
+    // lastRewardRound / lastFeeRound independently if the transcoder was inactive.
     let prevRoundNum = integerFromString(round.id).minus(ONE_BI);
-    let latestCumulativeFactorsPool = Pool.load(
+    let prevPool = Pool.load(
       makePoolId(currentTranscoder.toHex(), prevRoundNum.toString())
     );
-    if (!latestCumulativeFactorsPool && transcoder && transcoder.lastRewardRound) {
-      latestCumulativeFactorsPool = Pool.load(
-        makePoolId(currentTranscoder.toHex(), transcoder.lastRewardRound)
-      );
-    }
-    if (latestCumulativeFactorsPool) {
-      pool.cumulativeRewardFactor = latestCumulativeFactorsPool.cumulativeRewardFactor;
-      pool.cumulativeFeeFactor = latestCumulativeFactorsPool.cumulativeFeeFactor;
+    if (prevPool) {
+      pool.cumulativeRewardFactor = prevPool.cumulativeRewardFactor;
+      pool.cumulativeFeeFactor = prevPool.cumulativeFeeFactor;
     } else {
+      // CRF fallback to lastRewardRound
       pool.cumulativeRewardFactor = ZERO_BI;
+      if (transcoder && transcoder.lastRewardRound) {
+        let rewardPool = Pool.load(
+          makePoolId(currentTranscoder.toHex(), transcoder.lastRewardRound)
+        );
+        if (rewardPool) {
+          pool.cumulativeRewardFactor = rewardPool.cumulativeRewardFactor;
+        }
+      }
+      // CFF fallback to lastFeeRound
       pool.cumulativeFeeFactor = ZERO_BI;
+      if (transcoder && transcoder.lastFeeRound) {
+        let feePool = Pool.load(
+          makePoolId(currentTranscoder.toHex(), transcoder.lastFeeRound)
+        );
+        if (feePool) {
+          pool.cumulativeFeeFactor = feePool.cumulativeFeeFactor;
+        }
+      }
     }
 
     if (transcoder) {
@@ -161,8 +174,9 @@ export function newRound(event: NewRound): void {
       pool.rewardCut = transcoder.rewardCut;
       pool.feeShare = transcoder.feeShare;
 
-      // Snapshot pendingRewardCommission as activeCumulativeRewards for this round,
-      // mirroring the contract's setCurrentRoundTotalActiveStake snapshot
+      // Initial snapshot of activeCumulativeRewards for fees that arrive before
+      // reward(). The reward handler re-snapshots this to match the contract's
+      // exact timing (updateTranscoderWithRewards line 1490).
       transcoder.activeCumulativeRewards = transcoder.pendingRewardCommission;
       transcoder.save();
     }

--- a/src/mappings/roundsManager.ts
+++ b/src/mappings/roundsManager.ts
@@ -135,18 +135,22 @@ export function newRound(event: NewRound): void {
     pool.delegate = currentTranscoder.toHex();
     pool.fees = ZERO_BD;
 
-    // Propagate cumulative factors from the previous round's pool so every
-    // pool has valid factors even if the transcoder misses reward() or has
-    // no fees in a round. This mirrors the contract's latestCumulativeFactorsPool.
+    // Ensure every pool has valid cumulative factors even when reward() is
+    // missed or no fees are earned. Mirrors the contract's
+    // latestCumulativeFactorsPool(): try the previous round, fall back to
+    // lastRewardRound if the transcoder was inactive.
     let prevRoundNum = integerFromString(round.id).minus(ONE_BI);
-    let prevPoolId = makePoolId(
-      currentTranscoder.toHex(),
-      prevRoundNum.toString()
+    let latestCumulativeFactorsPool = Pool.load(
+      makePoolId(currentTranscoder.toHex(), prevRoundNum.toString())
     );
-    let prevPool = Pool.load(prevPoolId);
-    if (prevPool) {
-      pool.cumulativeRewardFactor = prevPool.cumulativeRewardFactor;
-      pool.cumulativeFeeFactor = prevPool.cumulativeFeeFactor;
+    if (!latestCumulativeFactorsPool && transcoder && transcoder.lastRewardRound) {
+      latestCumulativeFactorsPool = Pool.load(
+        makePoolId(currentTranscoder.toHex(), transcoder.lastRewardRound)
+      );
+    }
+    if (latestCumulativeFactorsPool) {
+      pool.cumulativeRewardFactor = latestCumulativeFactorsPool.cumulativeRewardFactor;
+      pool.cumulativeFeeFactor = latestCumulativeFactorsPool.cumulativeFeeFactor;
     } else {
       pool.cumulativeRewardFactor = ZERO_BI;
       pool.cumulativeFeeFactor = ZERO_BI;

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -137,6 +137,12 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
     }
 
     let delegatorsFees = percOf(event.params.faceValue, pool.feeShare);
+    let transcoderFeeCommission = event.params.faceValue.minus(delegatorsFees);
+
+    // Accumulate orchestrator fee commission
+    transcoder.pendingFeeCommission = transcoder.pendingFeeCommission.plus(transcoderFeeCommission);
+    transcoder.lifetimeFeeCommission = transcoder.lifetimeFeeCommission.plus(transcoderFeeCommission);
+
     let totalStakeBI = convertFromDecimal(pool.totalStake);
     if (totalStakeBI.gt(ZERO_BI)) {
       pool.cumulativeFeeFactor = pool.cumulativeFeeFactor.plus(

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -144,13 +144,19 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
     let delegatorsFees = percOf(event.params.faceValue, pool.feeShare);
     let transcoderCommissionFees = event.params.faceValue.minus(delegatorsFees);
 
-    // Compute fees earned by the transcoder's own staked commission
+    // Compute fees earned by the transcoder's own staked commission.
+    // If reward() hasn't been called yet this round, use pendingRewardCommission
+    // directly (mirrors contract's updateTranscoderWithFees line 339).
+    let activeCumulativeRewards = transcoder.lastRewardRound == round.id
+      ? transcoder.activeCumulativeRewards
+      : transcoder.pendingRewardCommission;
+
     let totalStakeBI = convertFromDecimal(pool.totalStake);
     let transcoderRewardStakeFees = ZERO_BI;
     if (totalStakeBI.gt(ZERO_BI)) {
       transcoderRewardStakeFees = precisePercOf(
         delegatorsFees,
-        transcoder.activeCumulativeRewards,
+        activeCumulativeRewards,
         totalStakeBI
       );
     }
@@ -166,6 +172,7 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
       );
     }
 
+    transcoder.lastFeeRound = round.id;
     pool.fees = pool.fees.plus(faceValue);
     pool.save();
   }

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -1,5 +1,6 @@
 import { Address, BigInt, dataSource, log } from "@graphprotocol/graph-ts";
 import {
+  convertFromDecimal,
   convertToDecimal,
   createOrLoadBroadcaster,
   createOrLoadBroadcasterDay,
@@ -11,9 +12,15 @@ import {
   createOrLoadTranscoderDay,
   getBlockNum,
   getEthPriceUsd,
+  integerFromString,
   makeEventId,
   makePoolId,
+  ONE_BI,
+  percOf,
+  PRECISE_PERC_DIVISOR,
+  precisePercOf,
   ZERO_BD,
+  ZERO_BI,
 } from "../../utils/helpers";
 import {
   DepositFundedEvent,
@@ -113,8 +120,30 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   protocol.winningTicketCount = protocol.winningTicketCount + 1;
   protocol.save();
 
-  // update the transcoder pool fees
+  // update the transcoder pool fees and cumulative fee factor
   if (pool) {
+    // Compute cumulative fee factor (matches on-chain PreciseMathUtils)
+    // Use previous round's CRF, matching contract's latestCumulativeFactorsPool(_round - 1)
+    let prevRoundNum = integerFromString(round.id).minus(ONE_BI);
+    let prevPoolForFees = Pool.load(
+      makePoolId(event.params.recipient.toHex(), prevRoundNum.toString())
+    );
+    let prevCRF = PRECISE_PERC_DIVISOR; // default: 10^27
+    if (
+      prevPoolForFees &&
+      !prevPoolForFees.cumulativeRewardFactor.equals(ZERO_BI)
+    ) {
+      prevCRF = prevPoolForFees.cumulativeRewardFactor;
+    }
+
+    let delegatorsFees = percOf(event.params.faceValue, pool.feeShare);
+    let totalStakeBI = convertFromDecimal(pool.totalStake);
+    if (totalStakeBI.gt(ZERO_BI)) {
+      pool.cumulativeFeeFactor = pool.cumulativeFeeFactor.plus(
+        precisePercOf(prevCRF, delegatorsFees, totalStakeBI)
+      );
+    }
+
     pool.fees = pool.fees.plus(faceValue);
     pool.save();
   }

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -137,13 +137,24 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
     }
 
     let delegatorsFees = percOf(event.params.faceValue, pool.feeShare);
-    let transcoderFeeCommission = event.params.faceValue.minus(delegatorsFees);
+    let transcoderCommissionFees = event.params.faceValue.minus(delegatorsFees);
 
-    // Accumulate orchestrator fee commission
-    transcoder.pendingFeeCommission = transcoder.pendingFeeCommission.plus(transcoderFeeCommission);
-    transcoder.lifetimeFeeCommission = transcoder.lifetimeFeeCommission.plus(transcoderFeeCommission);
-
+    // Compute fees earned by the transcoder's own staked commission
     let totalStakeBI = convertFromDecimal(pool.totalStake);
+    let transcoderRewardStakeFees = ZERO_BI;
+    if (totalStakeBI.gt(ZERO_BI)) {
+      transcoderRewardStakeFees = precisePercOf(
+        delegatorsFees,
+        transcoder.activeCumulativeRewards,
+        totalStakeBI
+      );
+    }
+
+    // Accumulate orchestrator fee commission (feeShare cut + fees on staked commission)
+    let totalFeeCommission = transcoderCommissionFees.plus(transcoderRewardStakeFees);
+    transcoder.pendingFeeCommission = transcoder.pendingFeeCommission.plus(totalFeeCommission);
+    transcoder.lifetimeFeeCommission = transcoder.lifetimeFeeCommission.plus(totalFeeCommission);
+
     if (totalStakeBI.gt(ZERO_BI)) {
       pool.cumulativeFeeFactor = pool.cumulativeFeeFactor.plus(
         precisePercOf(prevCRF, delegatorsFees, totalStakeBI)

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -122,8 +122,9 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
 
   // update the transcoder pool fees and cumulative fee factor
   if (pool) {
-    // Compute cumulative fee factor (matches on-chain PreciseMathUtils)
-    // Use previous round's CRF, matching contract's latestCumulativeFactorsPool(_round - 1)
+    // Use previous round's CRF for fee factor calculation, matching the
+    // contract's latestCumulativeFactorsPool(currentRound - 1). Fall back
+    // to the current pool's propagated CRF on reactivation (no prev pool).
     let prevRoundNum = integerFromString(round.id).minus(ONE_BI);
     let prevPoolForFees = Pool.load(
       makePoolId(event.params.recipient.toHex(), prevRoundNum.toString())
@@ -134,6 +135,10 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
       !prevPoolForFees.cumulativeRewardFactor.equals(ZERO_BI)
     ) {
       prevCRF = prevPoolForFees.cumulativeRewardFactor;
+    } else if (!pool.cumulativeRewardFactor.equals(ZERO_BI)) {
+      // Current pool's CRF was propagated from lastRewardRound in newRound,
+      // so it holds the correct previous factor when prev pool doesn't exist.
+      prevCRF = pool.cumulativeRewardFactor;
     }
 
     let delegatorsFees = percOf(event.params.faceValue, pool.feeShare);

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -276,8 +276,10 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.sixtyDayVolumeETH = ZERO_BD;
     transcoder.ninetyDayVolumeETH = ZERO_BD;
     transcoder.transcoderDays = [];
-    transcoder.cumulativeRewards = ZERO_BI;
-    transcoder.lifetimeRewards = ZERO_BI;
+    transcoder.pendingRewardCommission = ZERO_BI;
+    transcoder.lifetimeRewardCommission = ZERO_BI;
+    transcoder.pendingFeeCommission = ZERO_BI;
+    transcoder.lifetimeFeeCommission = ZERO_BI;
     transcoder.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -31,6 +31,7 @@ export let EMPTY_ADDRESS = Address.fromString(
   "0000000000000000000000000000000000000000"
 );
 export let PERC_DIVISOR = 1000000;
+export let PRECISE_PERC_DIVISOR = BigInt.fromI32(10).pow(27);
 
 export let ZERO_BI = BigInt.fromI32(0);
 export let ONE_BI = BigInt.fromI32(1);
@@ -94,16 +95,6 @@ export function percOf(_amount: BigInt, _fracNum: BigInt): BigInt {
 
 export function percPoints(_fracNum: BigInt, _fracDenom: BigInt): BigInt {
   return _fracNum.times(BigInt.fromI32(PERC_DIVISOR)).div(_fracDenom);
-}
-
-// PreciseMathUtils equivalents (matches Solidity's 27-decimal fixed-point arithmetic)
-export let PRECISE_PERC_DIVISOR = BigInt.fromI32(10).pow(27);
-
-export function precisePercPoints(
-  _fracNum: BigInt,
-  _fracDenom: BigInt
-): BigInt {
-  return _fracNum.times(PRECISE_PERC_DIVISOR).div(_fracDenom);
 }
 
 export function precisePercOf(

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -265,9 +265,9 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.transcoderDays = [];
     transcoder.pendingRewardCommission = ZERO_BI;
     transcoder.lifetimeRewardCommission = ZERO_BI;
+    transcoder.activeCumulativeRewards = ZERO_BI;
     transcoder.pendingFeeCommission = ZERO_BI;
     transcoder.lifetimeFeeCommission = ZERO_BI;
-    transcoder.activeCumulativeRewards = ZERO_BI;
     transcoder.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -113,9 +113,7 @@ export function precisePercOf(
   _fracNum: BigInt,
   _fracDenom: BigInt
 ): BigInt {
-  return _baseAmount
-    .times(precisePercPoints(_fracNum, _fracDenom))
-    .div(PRECISE_PERC_DIVISOR);
+  return _baseAmount.times(_fracNum).div(_fracDenom);
 }
 
 // Convert BigDecimal (in token units) back to raw BigInt (in wei)

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -97,9 +97,7 @@ export function percPoints(_fracNum: BigInt, _fracDenom: BigInt): BigInt {
 }
 
 // PreciseMathUtils equivalents (matches Solidity's 27-decimal fixed-point arithmetic)
-export let PRECISE_PERC_DIVISOR = BigInt.fromString(
-  "1000000000000000000000000000"
-); // 10^27
+export let PRECISE_PERC_DIVISOR = BigInt.fromI32(10).pow(27);
 
 export function precisePercPoints(
   _fracNum: BigInt,

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -96,6 +96,38 @@ export function percPoints(_fracNum: BigInt, _fracDenom: BigInt): BigInt {
   return _fracNum.times(BigInt.fromI32(PERC_DIVISOR)).div(_fracDenom);
 }
 
+// PreciseMathUtils equivalents (matches Solidity's 27-decimal fixed-point arithmetic)
+export let PRECISE_PERC_DIVISOR = BigInt.fromString(
+  "1000000000000000000000000000"
+); // 10^27
+
+export function precisePercPoints(
+  _fracNum: BigInt,
+  _fracDenom: BigInt
+): BigInt {
+  return _fracNum.times(PRECISE_PERC_DIVISOR).div(_fracDenom);
+}
+
+export function precisePercOf(
+  _baseAmount: BigInt,
+  _fracNum: BigInt,
+  _fracDenom: BigInt
+): BigInt {
+  return _baseAmount
+    .times(precisePercPoints(_fracNum, _fracDenom))
+    .div(PRECISE_PERC_DIVISOR);
+}
+
+// Convert BigDecimal (in token units) back to raw BigInt (in wei)
+export function convertFromDecimal(amount: BigDecimal): BigInt {
+  let str = amount.times(exponentToBigDecimal(BI_18)).toString();
+  let dotIndex = str.indexOf(".");
+  if (dotIndex >= 0) {
+    str = str.substring(0, dotIndex);
+  }
+  return BigInt.fromString(str);
+}
+
 export function exponentToBigDecimal(decimals: BigInt): BigDecimal {
   let bd = BigDecimal.fromString("1");
   for (let i = ZERO_BI; i.lt(decimals); i = i.plus(ONE_BI)) {
@@ -265,6 +297,7 @@ export function createOrLoadDelegator(id: string, timestamp: i32): Delegator {
     delegator.fees = ZERO_BD;
     delegator.withdrawnFees = ZERO_BD;
     delegator.delegatedAmount = ZERO_BD;
+    delegator.shares = ZERO_BI;
     delegator.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -276,6 +276,7 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.sixtyDayVolumeETH = ZERO_BD;
     transcoder.ninetyDayVolumeETH = ZERO_BD;
     transcoder.transcoderDays = [];
+    transcoder.cumulativeRewards = ZERO_BI;
     transcoder.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -12,7 +12,9 @@ import {
   BroadcasterDay,
   Day,
   Delegator,
+  DelegatorSnapshot,
   LivepeerAccount,
+  Pool,
   Protocol,
   Round,
   Transaction,
@@ -103,6 +105,19 @@ export function precisePercOf(
   _fracDenom: BigInt
 ): BigInt {
   return _baseAmount.times(_fracNum).div(_fracDenom);
+}
+
+// Compute delegator shares: bondedAmount * 10^27 / CRF[currentRound]
+export function computeShares(delegate: string, roundId: string, bondedAmount: BigInt): BigInt {
+  if (bondedAmount.isZero()) {
+    return ZERO_BI;
+  }
+  let pool = Pool.load(makePoolId(delegate, roundId));
+  let crf = PRECISE_PERC_DIVISOR;
+  if (pool && !pool.cumulativeRewardFactor.equals(ZERO_BI)) {
+    crf = pool.cumulativeRewardFactor;
+  }
+  return bondedAmount.times(PRECISE_PERC_DIVISOR).div(crf);
 }
 
 // Convert BigDecimal (in token units) back to raw BigInt (in wei)
@@ -298,6 +313,24 @@ export function createOrLoadDelegator(id: string, timestamp: i32): Delegator {
   account.save();
 
   return delegator;
+}
+
+// Save a point-in-time record of delegator state for historical queries
+export function saveDelegatorSnapshot(
+  delegatorAddress: string,
+  delegate: string,
+  delegator: Delegator,
+  roundId: string,
+  timestamp: i32
+): void {
+  let snapshot = new DelegatorSnapshot(delegatorAddress + "-" + roundId);
+  snapshot.delegator = delegatorAddress;
+  snapshot.delegate = delegate;
+  snapshot.bondedAmount = delegator.bondedAmount;
+  snapshot.shares = delegator.shares;
+  snapshot.round = roundId;
+  snapshot.timestamp = timestamp;
+  snapshot.save();
 }
 
 export function createOrUpdateLivepeerAccount(id: string, timestamp: i32): LivepeerAccount {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -278,6 +278,7 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.lifetimeRewardCommission = ZERO_BI;
     transcoder.pendingFeeCommission = ZERO_BI;
     transcoder.lifetimeFeeCommission = ZERO_BI;
+    transcoder.activeCumulativeRewards = ZERO_BI;
     transcoder.save();
   }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -277,6 +277,7 @@ export function createOrLoadTranscoder(id: string, timestamp: i32): Transcoder {
     transcoder.ninetyDayVolumeETH = ZERO_BD;
     transcoder.transcoderDays = [];
     transcoder.cumulativeRewards = ZERO_BI;
+    transcoder.lifetimeRewards = ZERO_BI;
     transcoder.save();
   }
 


### PR DESCRIPTION
## Summary

Reconstructs the BondingManager's cumulative factor math and commission tracking in the subgraph, since the contract doesn't expose these values via events.

- **Cumulative Reward/Fee Factors** on Pool — mirrors the contract's `cumulativeRewardFactor` and `cumulativeFeeFactor` per transcoder per round, with proper propagation for missed rounds and reactivation gaps (independent `lastRewardRound`/`lastFeeRound` fallbacks)
- **Delegator shares** — precomputed `bondedAmount * 10^27 / CRF` for O(1) stake lookups at any round (`shares * CRF[round] / 10^27`)
- **DelegatorSnapshot** — historical shares records on bond/unbond/rebond for time-series queries
- **Orchestrator commission** — `pendingRewardCommission`, `pendingFeeCommission` (unclaimed, resets on claim) and `lifetimeRewardCommission`, `lifetimeFeeCommission` (never resets), including compounding on staked commission (`transcoderRewardStakeRewards` / `transcoderRewardStakeFees`)
- **activeCumulativeRewards** — snapshotted at round start and re-snapshotted in the reward handler to match the contract's exact timing (line 1490). Fee handler uses `pendingRewardCommission` directly when reward() hasn't been called yet (mirrors contract line 339).

### Edge cases handled
- Cumulative factor propagation falls back independently to `lastRewardRound` (CRF) and `lastFeeRound` (CFF) when previous pool is missing (transcoder reactivation)
- Fee handler uses current pool's propagated CRF as `prevCRF` fallback on reactivation
- `activeCumulativeRewards` preserved on claim (matches contract), re-snapshotted by reward handler
- Commission reset on `earningsClaimed` when delegator == delegate

### Known limitations
- Fee math uses `faceValue` from event, not `amountToTransfer` (see #229)

## Test plan
- [ ] Run `yarn prepare && yarn codegen && yarn build`
- [ ] Deploy to Subgraph Studio and verify sync completes without errors
- [ ] Compare `shares * CRF / 10^27 + pendingRewardCommission` against contract's `pendingStake()` for sample transcoders
- [ ] Verify commission resets to zero after an orchestrator claims earnings
- [ ] Verify cumulative factors propagate correctly across rounds where reward() is not called

🤖 Generated with [Claude Code](https://claude.com/claude-code)