### PR TITLE
Add indexerHints prune: 50000 to survive reorgs and bound history

### DIFF
--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1,8 +1,15 @@
-specVersion: 0.0.2
+specVersion: 1.0.0
 description: A protocol for affordable and reliable video encoding. Find transcoders, delegators, earning pools, and staking rounds.
 repository: https://github.com/livepeer/subgraph
 schema:
   file: ./schema.graphql
+indexerHints:
+  # Retain ~50k blocks of history (~3.5h on Arbitrum) — far deeper than any
+  # plausible reorg, so the indexer can always revert to follow the canonical
+  # chain (avoids the "revert beyond earliest_block" wedge) while keeping
+  # storage bounded. The apps only do current-state queries, not time-travel,
+  # so full archive (prune: never) isn't needed.
+  prune: 50000
 dataSources:
   - kind: ethereum/contract
     name: BondingManager


### PR DESCRIPTION
## Problem

The manifest sets no `indexerHints`, so the indexer applies **default history pruning**. When a chain reorg requires reverting blocks deeper than the retained history, graph-node fails with:

> `store error: No rows affected … attempt to revert beyond earliest_block + reorg_threshold`

and gets stuck in an infinite revert-retry loop. The subgraph **stops advancing** while continuing to serve stale data — and `hasIndexingErrors` stays `false`, so it looks healthy. We hit exactly this on the Arbitrum One deployment (stuck ~3 days at one block until redeployed with a fresh hash).

## Fix

Add bounded history retention:

```yaml
indexerHints:
  prune: 50000
```

- **~50k blocks ≈ 3.5h on Arbitrum** — far deeper than any realistic reorg, so the indexer can always revert to the canonical chain and won't wedge.
- **Bounded storage** — full archive (`prune: never`) isn't needed here: consumers do current-state queries, not time-travel.
- Requires bumping **`specVersion` 0.0.2 → 1.0.0**, which Subgraph Studio/graph-node mandates for `indexerHints`. Mapping `apiVersion` is unchanged (0.0.6).

## Notes

- `prune` takes `never | auto | <block count>`; the integer form is the bounded window (there is no separate `history_blocks` key).
- Changing the manifest changes the deployment hash, so this requires a fresh deploy + resync to take effect (already deployed to staging as v0.0.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the subgraph configuration to a newer specification version.
  * Added a history retention setting to limit how much past data is kept.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->