### PR TITLE
fix: set Transaction.to to zero address for contract-creation txs

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -123,6 +123,12 @@ export function createOrLoadTransactionFromEvent<T extends ethereum.Event>(
 
     if (event.transaction.to) {
       tx.to = event.transaction.to!.toHex();
+    } else {
+      // Contract-creation transactions have no `to` address. `Transaction.to`
+      // is non-nullable, so default to the zero address; leaving it unset makes
+      // graph-node abort with a fatal "missing value for non-nullable field
+      // `to`" error whenever a protocol event is emitted from a constructor.
+      tx.to = EMPTY_ADDRESS.toHex();
     }
 
     tx.save();


### PR DESCRIPTION
## Problem
The subgraph halts on any contract-creation transaction that emits a protocol event. On 2026-07-18 this froze Arbitrum One at block `485100964`; all 9 indexers report `health: failed` with `missing value for non-nullable field 'to'`. See #243.

## Root cause
`createOrLoadTransactionFromEvent` (`utils/helpers.ts`) skips `tx.to` when `event.transaction.to` is null, but `Transaction.to` is `String!` (non-nullable). Contract-creation txs have a null `to`, so graph-node aborts deterministically.

## Fix
Default `tx.to` to the zero address (`EMPTY_ADDRESS`) when the tx has no recipient. Keeps the schema non-nullable — no downstream/type changes.

## Testing
`yarn codegen` and `yarn build` pass.

## Deployment
Redeploy and **graft from block `485100964`** (last good block) so indexers resume instead of full-resyncing. Republish so subgraph `FE63…` points at the fixed deployment.

Fixes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JoKwkmU3jMU6DMGoTcCKRe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contract-creation transactions by assigning a default empty address when no recipient address is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->