### PR TITLE
fix: make Transaction.to nullable for contract-creation txs

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -476,8 +476,8 @@ type Transaction @entity {
   gasPrice: BigInt!
   "The sending party of the transaction"
   from: String!
-  "The receiving party of the transaction"
-  to: String!
+  "The receiving party of the transaction - null for contract-creation transactions"
+  to: String
   "The events emitted within this transaction"
   events: [Event!] @derivedFrom(field: "transaction")
 }


### PR DESCRIPTION
## Problem
Contract-creation transactions (e.g. a Tenderize unlock deployed via its constructor) have no recipient, so `event.transaction.to` is `null`. `Transaction.to` was `String!`, so `createOrLoadTransactionFromEvent` left it unset and graph-node aborted with `missing value for non-nullable field 'to'` — deterministically halting the subgraph. First hit 2026-07-18 at block `485100965`. See #243.

## Fix
Make `Transaction.to` nullable: `String!` → `String`. A creation tx genuinely has no recipient, so `null` is the correct value — it matches Ethereum/JSON-RPC and graph-ts itself (`to: Address | null`). No mapping change is needed: the existing conditional assignment already leaves `to` null for creation txs. Only `Transaction.to` changes; `MintEvent.to` stays non-null (it's an event parameter, always present).

## Alternative: default to the zero address (#244)
You *can* instead default `to` to the zero address (`EMPTY_ADDRESS`), which avoids the schema change. We prefer nullable because the zero address is **less accurate**: it reuses a real, valid address (`0x0`, the burn address) as a stand-in for "no recipient," so a consumer can't distinguish a contract-creation tx from an actual transfer to `0x0`. `null` states what is true.

## Testing
`yarn codegen` and `yarn build` pass. The Livepeer Explorer does not read `Transaction.to`, so the nullable change is safe for it.

## Deployment
Redeploys with a full resync (grafting is disabled). Republish so subgraph `FE63…` points at the fixed deployment.

Fixes #243