### PR TITLE
fix: create Pool on demand in reward() to avoid null-Pool abort

### DIFF
--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -13,6 +13,7 @@ import {
   makeUnbondingLockId,
   MAXIMUM_VALUE_UINT256,
   ONE_BI,
+  ZERO_BD,
   ZERO_BI,
 } from "../../utils/helpers";
 // Import event types from the registrar contract ABIs
@@ -486,6 +487,21 @@ export function reward(event: Reward): void {
   let poolId = makePoolId(event.params.transcoder.toHex(), round.id);
   let pool = Pool.load(poolId);
   let protocol = createOrLoadProtocol();
+
+  // A Pool is normally created for every active transcoder in newRound(). If a
+  // transcoder emits Reward for a round that has no Pool (e.g. its NewRound was
+  // never indexed, getFirstTranscoderInPool reverted so no pools were created,
+  // or the transcoder was absent from the round's pool snapshot) then
+  // Pool.load() returns null. Create it on demand so indexing never aborts on a
+  // null Pool. totalStake is read before the reward is added below, matching the
+  // start-of-round stake semantics newRound() uses.
+  if (pool == null) {
+    pool = new Pool(poolId);
+    pool.round = round.id;
+    pool.delegate = event.params.transcoder.toHex();
+    pool.fees = ZERO_BD;
+    pool.totalStake = transcoder.totalStake;
+  }
 
   delegate.delegatedAmount = delegate.delegatedAmount.plus(
     convertToDecimal(event.params.amount)


### PR DESCRIPTION
## Problem
`reward()` loads the round's `Pool` with `Pool.load()` and dereferences it with `pool!`, which **hard-aborts** the subgraph when the Pool is missing:

```
Mapping aborted at src/mappings/bondingManager.ts, line 499:
  unexpected null in handler `reward` at block #144056642
```

Observed on the Subgraph Studio indexer for the Livepeer subgraph.

## Root cause (as far as traced)
Pools are created only in `newRound()`, built from on-chain `eth_call`s (`getFirstTranscoderInPool` / `getNextTranscoderInPool`). When that set comes out empty or short for a round, a transcoder that later calls `reward()` has no Pool → `Pool.load()` returns null → `pool!` aborts.

This is **non-deterministic**: with identical code, one indexer aborted at 144056642 while the live network deployment indexed straight past it. That points to the pool-building `eth_call`s resolving differently across archive environments/syncs. The precise reason the set is built short is **not fully pinned down** (deep-archive `eth_call` behavior vs a genuine on-chain edge case). Either way, `reward()` should never hard-halt on a missing Pool.

## Fix
Create the Pool on demand when it's missing, populating the same non-null fields `newRound()` sets:

```ts
if (pool == null) {
  pool = new Pool(poolId);
  pool.round = round.id;
  pool.delegate = event.params.transcoder.toHex();
  pool.fees = ZERO_BD;
  pool.totalStake = transcoder.totalStake;
}
```

## Validation
Reproduced locally against an Arbitrum One **archive** RPC: the pre-fix build aborts at 144056642 (`unexpected null in handler reward`); this build runs the `reward` handler and indexes past it (`Done processing trigger … handler: reward`).

## Notes
- **Defensive** fix — it only runs when the Pool is already missing, so it cannot make things worse. Caveat: the on-demand Pool uses the transcoder's current values, so that one edge-case round's Pool data may be slightly off — better than a hard halt.
- On a resync, block 144056642 comes **before** the #243 `to`-bug block (485100965), so this guard is needed for a clean resync to even reach that fix. A combined PR ships this together with the `Transaction.to` nullable fix (#245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward processing when pool information is unavailable.
  * Pools are now initialized automatically with accurate staking and reward data, preventing indexing interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->