### PR TITLE
fix: unblock indexing — nullable Transaction.to + reward Pool guard

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -476,8 +476,8 @@ type Transaction @entity {
   gasPrice: BigInt!
   "The sending party of the transaction"
   from: String!
-  "The receiving party of the transaction"
-  to: String!
+  "The receiving party of the transaction - null for contract-creation transactions"
+  to: String
   "The events emitted within this transaction"
   events: [Event!] @derivedFrom(field: "transaction")
 }

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -13,6 +13,7 @@ import {
   makeUnbondingLockId,
   MAXIMUM_VALUE_UINT256,
   ONE_BI,
+  ZERO_BD,
   ZERO_BI,
 } from "../../utils/helpers";
 // Import event types from the registrar contract ABIs
@@ -486,6 +487,21 @@ export function reward(event: Reward): void {
   let poolId = makePoolId(event.params.transcoder.toHex(), round.id);
   let pool = Pool.load(poolId);
   let protocol = createOrLoadProtocol();
+
+  // A Pool is normally created for every active transcoder in newRound(). If a
+  // transcoder emits Reward for a round that has no Pool (e.g. its NewRound was
+  // never indexed, getFirstTranscoderInPool reverted so no pools were created,
+  // or the transcoder was absent from the round's pool snapshot) then
+  // Pool.load() returns null. Create it on demand so indexing never aborts on a
+  // null Pool. totalStake is read before the reward is added below, matching the
+  // start-of-round stake semantics newRound() uses.
+  if (pool == null) {
+    pool = new Pool(poolId);
+    pool.round = round.id;
+    pool.delegate = event.params.transcoder.toHex();
+    pool.fees = ZERO_BD;
+    pool.totalStake = transcoder.totalStake;
+  }
 
   delegate.delegatedAmount = delegate.delegatedAmount.plus(
     convertToDecimal(event.params.amount)


### PR DESCRIPTION
Single PR to **unblock the Livepeer subgraph in one deploy**. Combines two independent fixes (also open separately as #245 and #246):

## 1. `Transaction.to` nullable (#245)
Fixes the **deterministic** halt at block **485100965** — a Tenderize unlock deployed via a constructor has no recipient, so `event.transaction.to` is null, but `Transaction.to` was `String!`:

```
missing value for non-nullable field `to`  (handler: earningsClaimed)
```

Change: `schema.graphql` `Transaction.to: String!` → `String`. Matches graph-ts (`to: Address | null`) and Ethereum (a creation tx `to` is null). No mapping change.

## 2. Pool guard in `reward()` (#246)
Stops `reward()` hard-aborting on a missing Pool at block **144056642**:

```
unexpected null in handler `reward`  (bondingManager.ts:499)
```

Change: create the Pool on demand when `Pool.load()` is null.

## Why combined
Grafting is disabled, so any redeploy triggers a full resync. On that resync, block **144056642** (reward) comes **before** **485100965** (`to`), so **both** fixes are needed for the subgraph to sync cleanly past the current halt. Deploy this branch to fix production in one shot.

## Validation
Both reproduced and fixed locally against an Arbitrum One **archive** RPC — the pre-fix build aborts at 485100965 and 144056642, this branch indexes past both. `yarn codegen` + `yarn build` pass.

Full root-cause notes in #245 (deterministic `to` bug) and #246 (defensive Pool guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)