### PR TITLE
fix: create missing Pool on demand to avoid null-Pool abort

### DIFF
--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -2,6 +2,7 @@ import { store } from "@graphprotocol/graph-ts";
 import {
   convertToDecimal,
   createOrLoadDelegator,
+  createOrLoadPool,
   createOrLoadProtocol,
   createOrLoadRound,
   createOrLoadTransactionFromEvent,
@@ -9,7 +10,6 @@ import {
   EMPTY_ADDRESS,
   getBlockNum,
   makeEventId,
-  makePoolId,
   makeUnbondingLockId,
   MAXIMUM_VALUE_UINT256,
   ONE_BI,
@@ -36,7 +36,6 @@ import {
   BondEvent,
   EarningsClaimedEvent,
   ParameterUpdateEvent,
-  Pool,
   RebondEvent,
   RewardEvent,
   TranscoderActivatedEvent,
@@ -483,8 +482,7 @@ export function reward(event: Reward): void {
     event.block.timestamp.toI32()
   );
   let round = createOrLoadRound(getBlockNum());
-  let poolId = makePoolId(event.params.transcoder.toHex(), round.id);
-  let pool = Pool.load(poolId);
+  let pool = createOrLoadPool(round.id, event.params.transcoder.toHex());
   let protocol = createOrLoadProtocol();
 
   delegate.delegatedAmount = delegate.delegatedAmount.plus(
@@ -496,13 +494,13 @@ export function reward(event: Reward): void {
   );
   transcoder.lastRewardRound = round.id;
 
-  pool!.rewardTokens = convertToDecimal(event.params.amount);
-  pool!.feeShare = transcoder.feeShare;
-  pool!.rewardCut = transcoder.rewardCut;
+  pool.rewardTokens = convertToDecimal(event.params.amount);
+  pool.feeShare = transcoder.feeShare;
+  pool.rewardCut = transcoder.rewardCut;
 
   transcoder.save();
   delegate.save();
-  pool!.save();
+  pool.save();
   protocol.save();
 
   createOrLoadTransactionFromEvent(event);

--- a/src/mappings/roundsManager.ts
+++ b/src/mappings/roundsManager.ts
@@ -2,6 +2,7 @@ import { Address, BigDecimal, BigInt, log } from "@graphprotocol/graph-ts";
 import {
   convertToDecimal,
   createOrLoadDay,
+  createOrLoadPool,
   createOrLoadProtocol,
   createOrLoadRound,
   createOrLoadTransactionFromEvent,
@@ -13,7 +14,6 @@ import {
   getLptPriceEth,
   getTimestampForDaysPast,
   makeEventId,
-  makePoolId,
   ONE_BD,
   ONE_BI,
   PERC_DIVISOR,
@@ -32,7 +32,6 @@ import {
   BroadcasterDay,
   NewRoundEvent,
   ParameterUpdateEvent,
-  Pool,
   Transcoder,
   TranscoderDay,
 } from "../types/schema";
@@ -76,8 +75,6 @@ export function newRound(event: NewRound): void {
   round.totalActiveStake = totalActiveStake;
   round.save();
 
-  let poolId: string;
-  let pool: Pool;
   let protocol = createOrLoadProtocol();
 
   // Activate all transcoders pending activation
@@ -127,17 +124,7 @@ export function newRound(event: NewRound): void {
     // reward() for a given round, we store its reward tokens inside this Pool
     // entry in a field called "rewardTokens". If "rewardTokens" is null for a
     // given transcoder and round then we know the transcoder failed to call reward()
-    poolId = makePoolId(currentTranscoder.toHex(), round.id);
-    pool = new Pool(poolId);
-    pool.round = round.id;
-    pool.delegate = currentTranscoder.toHex();
-    pool.fees = ZERO_BD;
-    if (transcoder) {
-      pool.totalStake = transcoder.totalStake;
-      pool.rewardCut = transcoder.rewardCut;
-      pool.feeShare = transcoder.feeShare;
-    }
-    pool.save();
+    createOrLoadPool(round.id, currentTranscoder.toHex());
 
     currentTranscoder =
       bondingManager.getNextTranscoderInPool(currentTranscoder);

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -4,6 +4,7 @@ import {
   createOrLoadBroadcaster,
   createOrLoadBroadcasterDay,
   createOrLoadDay,
+  createOrLoadPool,
   createOrLoadProtocol,
   createOrLoadRound,
   createOrLoadTransactionFromEvent,
@@ -12,12 +13,10 @@ import {
   getBlockNum,
   getEthPriceUsd,
   makeEventId,
-  makePoolId,
   ZERO_BD,
 } from "../../utils/helpers";
 import {
   DepositFundedEvent,
-  Pool,
   ReserveClaimedEvent,
   ReserveFundedEvent,
   WinningTicketRedeemedEvent,
@@ -42,8 +41,6 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   let faceValue = convertToDecimal(event.params.faceValue);
   let ethPrice = getEthPriceUsd();
   let faceValueUSD = faceValue.times(ethPrice);
-  let poolId = makePoolId(event.params.recipient.toHex(), round.id);
-  let pool = Pool.load(poolId);
 
   createOrLoadTransactionFromEvent(event);
 
@@ -102,7 +99,7 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   // Update transcoder's fee volume
   let transcoder = createOrLoadTranscoder(
     event.params.recipient.toHex(),
-    event.block.timestamp.toI32()
+    timestamp
   );
   transcoder.totalVolumeETH = transcoder.totalVolumeETH.plus(faceValue);
   transcoder.totalVolumeUSD = transcoder.totalVolumeUSD.plus(faceValueUSD);
@@ -122,10 +119,9 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   protocol.save();
 
   // update the transcoder pool fees
-  if (pool) {
-    pool.fees = pool.fees.plus(faceValue);
-    pool.save();
-  }
+  let pool = createOrLoadPool(round.id, event.params.recipient.toHex());
+  pool.fees = pool.fees.plus(faceValue);
+  pool.save();
 
   day.totalSupply = protocol.totalSupply;
   day.totalActiveStake = protocol.totalActiveStake;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -13,6 +13,7 @@ import {
   Day,
   Delegator,
   LivepeerAccount,
+  Pool,
   Protocol,
   Round,
   Transaction,
@@ -49,6 +50,33 @@ export function leftPad(str: string, size: i32): string {
 // Make a derived pool ID from a transcoder address
 export function makePoolId(transcoderAddress: string, roundId: string): string {
   return leftPad(roundId, 10) + "-" + transcoderAddress;
+}
+
+export function createOrLoadPool(roundId: string, transcoderAddress: string): Pool {
+  let poolId = makePoolId(transcoderAddress, roundId);
+  let pool = Pool.load(poolId);
+
+  if (pool == null) {
+    pool = new Pool(poolId);
+    pool.round = roundId;
+    pool.delegate = transcoderAddress;
+    pool.fees = ZERO_BD;
+    let transcoder = Transcoder.load(transcoderAddress);
+
+    if (transcoder) {
+      pool.totalStake = transcoder.totalStake;
+      pool.rewardCut = transcoder.rewardCut;
+      pool.feeShare = transcoder.feeShare;
+    } else {
+      // Failsafe: the Transcoder should exist, but default the non-nullable
+      // fields if it is missing so save() cannot abort.
+      pool.totalStake = ZERO_BD;
+      pool.rewardCut = ZERO_BI;
+      pool.feeShare = ZERO_BI;
+    }
+    pool.save();
+  }
+  return pool;
 }
 
 // Make a derived share ID from a delegator address


### PR DESCRIPTION
## Problem

`reward()` aborts on a null `Pool` (the halt at block 144056642) and `ticketBroker` silently drops the fees when a round's `Pool` was never built. `newRound` builds Pools by walking the on-chain pool with an `eth_call` enumeration, which is non-deterministic and can come up short. See #248 for the root cause.

## Fix

Add `createOrLoadPool(round, transcoderAddress)` and use it in `newRound`, `reward`, and `ticketBroker`, so the Pool is always built through one code path and no handler aborts on a null Pool.

- **Single writer** — the helper is the only place a Pool is created, setting the round snapshot (`totalStake`/`rewardCut`/`feeShare`) once. Handlers only add their own accumulator (`reward` → `rewardTokens`, `ticketBroker` → `fees`), never re-touching the snapshot.
- **No `!`** — the helper returns a non-null Pool and defaults the non-nullable fields if the Transcoder is ever missing, so `save()` can't abort (matches The Graph's `unexpected-null` linter guidance).
- **Unchanged on a full sync** — the transcoder always exists (from `Bond`/register logs), so Pools get real values. The default branch is a failsafe.

## Notes

- Pool fix only. Ship together with the `Transaction.to` nullable fix (#245) — 144056642 comes before the `to`-bug block (485100965).
- Cross-indexer POI consistency of Pools needs a reliable enumeration — that is #248.