### PR TITLE
fix: create Pool on demand + nullable Transaction.to (combined production fix)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -476,8 +476,8 @@ type Transaction @entity {
   gasPrice: BigInt!
   "The sending party of the transaction"
   from: String!
-  "The receiving party of the transaction"
-  to: String!
+  "The receiving party of the transaction - null for contract-creation transactions"
+  to: String
   "The events emitted within this transaction"
   events: [Event!] @derivedFrom(field: "transaction")
 }

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -2,6 +2,7 @@ import { store } from "@graphprotocol/graph-ts";
 import {
   convertToDecimal,
   createOrLoadDelegator,
+  createOrLoadPool,
   createOrLoadProtocol,
   createOrLoadRound,
   createOrLoadTransactionFromEvent,
@@ -9,7 +10,6 @@ import {
   EMPTY_ADDRESS,
   getBlockNum,
   makeEventId,
-  makePoolId,
   makeUnbondingLockId,
   MAXIMUM_VALUE_UINT256,
   ONE_BI,
@@ -36,7 +36,6 @@ import {
   BondEvent,
   EarningsClaimedEvent,
   ParameterUpdateEvent,
-  Pool,
   RebondEvent,
   RewardEvent,
   TranscoderActivatedEvent,
@@ -483,8 +482,7 @@ export function reward(event: Reward): void {
     event.block.timestamp.toI32()
   );
   let round = createOrLoadRound(getBlockNum());
-  let poolId = makePoolId(event.params.transcoder.toHex(), round.id);
-  let pool = Pool.load(poolId);
+  let pool = createOrLoadPool(round.id, event.params.transcoder.toHex());
   let protocol = createOrLoadProtocol();
 
   delegate.delegatedAmount = delegate.delegatedAmount.plus(
@@ -496,13 +494,13 @@ export function reward(event: Reward): void {
   );
   transcoder.lastRewardRound = round.id;
 
-  pool!.rewardTokens = convertToDecimal(event.params.amount);
-  pool!.feeShare = transcoder.feeShare;
-  pool!.rewardCut = transcoder.rewardCut;
+  pool.rewardTokens = convertToDecimal(event.params.amount);
+  pool.feeShare = transcoder.feeShare;
+  pool.rewardCut = transcoder.rewardCut;
 
   transcoder.save();
   delegate.save();
-  pool!.save();
+  pool.save();
   protocol.save();
 
   createOrLoadTransactionFromEvent(event);

--- a/src/mappings/roundsManager.ts
+++ b/src/mappings/roundsManager.ts
@@ -2,6 +2,7 @@ import { Address, BigDecimal, BigInt, log } from "@graphprotocol/graph-ts";
 import {
   convertToDecimal,
   createOrLoadDay,
+  createOrLoadPool,
   createOrLoadProtocol,
   createOrLoadRound,
   createOrLoadTransactionFromEvent,
@@ -13,7 +14,6 @@ import {
   getLptPriceEth,
   getTimestampForDaysPast,
   makeEventId,
-  makePoolId,
   ONE_BD,
   ONE_BI,
   PERC_DIVISOR,
@@ -32,7 +32,6 @@ import {
   BroadcasterDay,
   NewRoundEvent,
   ParameterUpdateEvent,
-  Pool,
   Transcoder,
   TranscoderDay,
 } from "../types/schema";
@@ -76,8 +75,6 @@ export function newRound(event: NewRound): void {
   round.totalActiveStake = totalActiveStake;
   round.save();
 
-  let poolId: string;
-  let pool: Pool;
   let protocol = createOrLoadProtocol();
 
   // Activate all transcoders pending activation
@@ -127,17 +124,7 @@ export function newRound(event: NewRound): void {
     // reward() for a given round, we store its reward tokens inside this Pool
     // entry in a field called "rewardTokens". If "rewardTokens" is null for a
     // given transcoder and round then we know the transcoder failed to call reward()
-    poolId = makePoolId(currentTranscoder.toHex(), round.id);
-    pool = new Pool(poolId);
-    pool.round = round.id;
-    pool.delegate = currentTranscoder.toHex();
-    pool.fees = ZERO_BD;
-    if (transcoder) {
-      pool.totalStake = transcoder.totalStake;
-      pool.rewardCut = transcoder.rewardCut;
-      pool.feeShare = transcoder.feeShare;
-    }
-    pool.save();
+    createOrLoadPool(round.id, currentTranscoder.toHex());
 
     currentTranscoder =
       bondingManager.getNextTranscoderInPool(currentTranscoder);

--- a/src/mappings/ticketBroker.ts
+++ b/src/mappings/ticketBroker.ts
@@ -4,6 +4,7 @@ import {
   createOrLoadBroadcaster,
   createOrLoadBroadcasterDay,
   createOrLoadDay,
+  createOrLoadPool,
   createOrLoadProtocol,
   createOrLoadRound,
   createOrLoadTransactionFromEvent,
@@ -12,12 +13,10 @@ import {
   getBlockNum,
   getEthPriceUsd,
   makeEventId,
-  makePoolId,
   ZERO_BD,
 } from "../../utils/helpers";
 import {
   DepositFundedEvent,
-  Pool,
   ReserveClaimedEvent,
   ReserveFundedEvent,
   WinningTicketRedeemedEvent,
@@ -42,8 +41,6 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   let faceValue = convertToDecimal(event.params.faceValue);
   let ethPrice = getEthPriceUsd();
   let faceValueUSD = faceValue.times(ethPrice);
-  let poolId = makePoolId(event.params.recipient.toHex(), round.id);
-  let pool = Pool.load(poolId);
 
   createOrLoadTransactionFromEvent(event);
 
@@ -102,7 +99,7 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   // Update transcoder's fee volume
   let transcoder = createOrLoadTranscoder(
     event.params.recipient.toHex(),
-    event.block.timestamp.toI32()
+    timestamp
   );
   transcoder.totalVolumeETH = transcoder.totalVolumeETH.plus(faceValue);
   transcoder.totalVolumeUSD = transcoder.totalVolumeUSD.plus(faceValueUSD);
@@ -122,10 +119,9 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   protocol.save();
 
   // update the transcoder pool fees
-  if (pool) {
-    pool.fees = pool.fees.plus(faceValue);
-    pool.save();
-  }
+  let pool = createOrLoadPool(round.id, event.params.recipient.toHex());
+  pool.fees = pool.fees.plus(faceValue);
+  pool.save();
 
   day.totalSupply = protocol.totalSupply;
   day.totalActiveStake = protocol.totalActiveStake;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -13,6 +13,7 @@ import {
   Day,
   Delegator,
   LivepeerAccount,
+  Pool,
   Protocol,
   Round,
   Transaction,
@@ -49,6 +50,33 @@ export function leftPad(str: string, size: i32): string {
 // Make a derived pool ID from a transcoder address
 export function makePoolId(transcoderAddress: string, roundId: string): string {
   return leftPad(roundId, 10) + "-" + transcoderAddress;
+}
+
+export function createOrLoadPool(roundId: string, transcoderAddress: string): Pool {
+  let poolId = makePoolId(transcoderAddress, roundId);
+  let pool = Pool.load(poolId);
+
+  if (pool == null) {
+    pool = new Pool(poolId);
+    pool.round = roundId;
+    pool.delegate = transcoderAddress;
+    pool.fees = ZERO_BD;
+    let transcoder = Transcoder.load(transcoderAddress);
+
+    if (transcoder) {
+      pool.totalStake = transcoder.totalStake;
+      pool.rewardCut = transcoder.rewardCut;
+      pool.feeShare = transcoder.feeShare;
+    } else {
+      // Failsafe: the Transcoder should exist, but default the non-nullable
+      // fields if it is missing so save() cannot abort.
+      pool.totalStake = ZERO_BD;
+      pool.rewardCut = ZERO_BI;
+      pool.feeShare = ZERO_BI;
+    }
+    pool.save();
+  }
+  return pool;
 }
 
 // Make a derived share ID from a delegator address


### PR DESCRIPTION
Combined production fix — the branch to deploy/verify. Bundles both crash fixes so a resync from genesis clears both:

- **#249** — `createOrLoadPool`: rebuild a missing Pool on demand so `reward()`/`ticketBroker()` never abort on a null Pool (the halt at **144056642**).
- **#245** — make `Transaction.to` nullable for contract-creation txs (the halt at **485100965**).

144056642 comes before 485100965, so both fixes must ship together for a clean resync from genesis.

Supersedes #247 (same combination, but with the inline guard #246 instead of the `createOrLoadPool` helper #249).

The deterministic root fix for the pool enumeration is tracked in #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
