### PR TITLE
chore: update package.json version to v1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livepeer/subgraph",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "scripts": {
     "prepare": "yarn prepare:arbitrum-one && yarn codegen && yarn codegen:typechain",


### PR DESCRIPTION
# Description

I fogot to increase the package.json version when tagging a new release this will fix this to ensure its in sync.

# Checklist

- [x] Ran `yarn prepare` and verified `yarn codegen` and `yarn build` succeed.
- [x] (Optional) Validated locally with `yarn deploy:local`.
- [x] Confirmed the Subgraph Studio preview link in the PR comment works and the subgraph syncs without errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the subgraph package to version 1.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->