### PR TITLE
feat: index RewardCallerSet reward caller delegation

### DIFF
--- a/abis/BondingManager.json
+++ b/abis/BondingManager.json
@@ -826,6 +826,25 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "transcoder",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "rewardCaller",
+        "type": "address"
+      }
+    ],
+    "name": "RewardCallerSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "newDelegate",
         "type": "address"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livepeer/subgraph",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "license": "MIT",
   "scripts": {
     "prepare": "yarn prepare:arbitrum-one && yarn codegen && yarn codegen:typechain",

--- a/schema.graphql
+++ b/schema.graphql
@@ -106,6 +106,8 @@ type Transcoder @entity {
   delegator: Delegator
   "Service URI endpoint that can be used to send off-chain requests"
   serviceURI: String
+  "Address delegated to call reward on the transcoder's behalf - null if unset"
+  rewardCaller: String
   "Days which the transcoder earned fees"
   transcoderDays: [TranscoderDay!]!
 }
@@ -584,6 +586,24 @@ type RewardEvent implements Event @entity {
   rewardTokens: BigDecimal!
   "Reference to the delegate that claimed its inflationary token reward"
   delegate: Transcoder!
+}
+
+"""
+RewardCallerSetEvent entities are created for every emitted RewardCallerSet event.
+"""
+type RewardCallerSetEvent implements Event @entity {
+  "Ethereum transaction hash + event log index"
+  id: ID!
+  "Reference to the transaction the event was included in"
+  transaction: Transaction!
+  "Timestamp of the transaction the event was included in"
+  timestamp: Int!
+  "Reference to the round the event occured in"
+  round: Round!
+  "Reference to the transcoder that set the reward caller"
+  delegate: Transcoder!
+  "Address authorized to call reward - the zero address when unset"
+  rewardCaller: String!
 }
 
 """

--- a/src/mappings/bondingManager.ts
+++ b/src/mappings/bondingManager.ts
@@ -23,6 +23,7 @@ import {
   ParameterUpdate,
   Rebond,
   Reward,
+  RewardCallerSet,
   TranscoderActivated,
   TranscoderDeactivated,
   TranscoderSlashed,
@@ -37,6 +38,7 @@ import {
   EarningsClaimedEvent,
   ParameterUpdateEvent,
   RebondEvent,
+  RewardCallerSetEvent,
   RewardEvent,
   TranscoderActivatedEvent,
   TranscoderDeactivatedEvent,
@@ -572,6 +574,34 @@ export function transcoderUpdate(event: TranscoderUpdate): void {
   transcoderUpdateEvent.feeShare = event.params.feeShare;
   transcoderUpdateEvent.delegate = event.params.transcoder.toHex();
   transcoderUpdateEvent.save();
+}
+
+export function rewardCallerSet(event: RewardCallerSet): void {
+  let round = createOrLoadRound(getBlockNum());
+  let transcoder = createOrLoadTranscoder(
+    event.params.transcoder.toHex(),
+    event.block.timestamp.toI32()
+  );
+
+  // The zero address unsets the reward caller
+  if (event.params.rewardCaller.toHex() == EMPTY_ADDRESS.toHex()) {
+    transcoder.rewardCaller = null;
+  } else {
+    transcoder.rewardCaller = event.params.rewardCaller.toHex();
+  }
+  transcoder.save();
+
+  createOrLoadTransactionFromEvent(event);
+
+  let rewardCallerSetEvent = new RewardCallerSetEvent(
+    makeEventId(event.transaction.hash, event.logIndex)
+  );
+  rewardCallerSetEvent.transaction = event.transaction.hash.toHex();
+  rewardCallerSetEvent.timestamp = event.block.timestamp.toI32();
+  rewardCallerSetEvent.round = round.id;
+  rewardCallerSetEvent.delegate = event.params.transcoder.toHex();
+  rewardCallerSetEvent.rewardCaller = event.params.rewardCaller.toHex();
+  rewardCallerSetEvent.save();
 }
 
 export function transcoderActivated(event: TranscoderActivated): void {

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -31,6 +31,7 @@ dataSources:
           - Pool
           - Protocol
           - RebondEvent
+          - RewardCallerSetEvent
           - RewardEvent
           - Transaction
           - Transcoder
@@ -61,6 +62,8 @@ dataSources:
           handler: withdrawStake
         - event: Reward(indexed address,uint256)
           handler: reward
+        - event: RewardCallerSet(indexed address,indexed address)
+          handler: rewardCallerSet
         - event: WithdrawFees(indexed address,address,uint256)
           handler: withdrawFees
         - event: ParameterUpdate(string)


### PR DESCRIPTION
# Description

[livepeer/protocol#648](https://github.com/livepeer/protocol/pull/648) lets an orchestrator nominate a single address it trusts to call `reward()` on its behalf, so the main wallet no longer has to stay unlocked every round. It adds one event, `RewardCallerSet(address indexed transcoder, address indexed rewardCaller)`, which the subgraph did not index — so a delegation was invisible to the Explorer and an orchestrator had no way to confirm from indexed data that it took effect.

This adds:

- `Transcoder.rewardCaller: String` — nullable, `null` when unset, alongside `serviceURI`
- `RewardCallerSetEvent` — the standard `Event` shape, recording the literal `0x0` on unset so
  unset actions stay in history
- A `rewardCallerSet` handler, following the `serviceURIUpdate` / `transcoderUpdate` pattern

The upgrade is already live on Arbitrum One (target `0xbe197fc…Bd2`, artifacts in livepeer/protocol#660), so these events can land today.

## The `Reward` path is deliberately untouched

PR 648 refactored `rewardWithHint` into a private `_rewardWithHint(_transcoder, ...)` and switched every emit inside it from `msg.sender` to `_transcoder`. The `Reward(indexed address,uint256)` signature and semantics are unchanged, so both existing handlers — `reward` in `bondingManager.ts` and `updatePollTallyOnReward` on the `PollTallyTemplate` — stay correct without modification.

One behavioural consequence worth knowing, no code change: once delegation is in use, `Transaction.from` on a reward tx is the reward caller, not the orchestrator. Per-event attribution via `RewardEvent.delegate` remains authoritative. No `caller` field was added to `RewardEvent` — it would duplicate `transaction.from`, which is already reachable and is transaction-level rather than per-event.

## ABI

The `RewardCallerSet` entry in `abis/BondingManager.json` was **added by hand**, copied from `deployments/arbitrumMainnet/BondingManagerTarget.json` in the protocol repo and diffed to confirm it matches byte-for-byte. This repo has no ABI sync mechanism, and the change was kept narrow rather than mixing a full resync into a feature PR.

Follow-up tracked in #252, which measures the current drift across all ABIs.

## Verification

`RewardCallerSet` cannot be exercised by the local test suite — the `livepeer/geth-with-livepeer-protocol:streamflow` image predates `setRewardCaller`. Two real on-chain events serve as fixtures instead, covering both the set and unset branches on the same transcoder, in order:

| Block | transcoder | rewardCaller |
|---|---|---|
| 489361725 | `0x8Ad7BCac720DdCc23cfB0b57fb3c7Da02368E947` | `0x…dEaD` (set) |
| 489361734 | `0x8Ad7BCac720DdCc23cfB0b57fb3c7Da02368E947` | `0x0` (unset) |

A correct implementation ends with `rewardCaller: null` and two `RewardCallerSetEvent` rows.

# Checklist

- [x] Ran `yarn prepare` and verified `yarn codegen` and `yarn build` succeed.
- [x] (Optional) Validated locally with `yarn deploy:local`.
- [x] Confirmed the Subgraph Studio preview link in the PR comment works and the subgraph syncs without errors.