### PR TITLE
Update the Discord badge to the current invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Livepeer Subgraph
 
-[![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/livepeer)
+[![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/55SZFEEH5y)
 [![Onchain Deploy](https://github.com/livepeer/subgraph/actions/workflows/deploy.yml/badge.svg)](https://github.com/livepeer/subgraph/actions/workflows/deploy.yml)
 [![Staging Deploy](https://github.com/livepeer/subgraph/actions/workflows/staging.yml/badge.svg)](https://github.com/livepeer/subgraph/actions/workflows/staging.yml)
 [![Tag Version Check](https://github.com/livepeer/subgraph/actions/workflows/version-check.yml/badge.svg)](https://github.com/livepeer/subgraph/actions/workflows/version-check.yml)


### PR DESCRIPTION
## What changed

The `discord.gg/livepeer` vanity URL no longer resolves to the Livepeer Discord server. The README badge now points at the current, non-expiring invite `https://discord.gg/55SZFEEH5y`.

Docs only; no code paths touched.

## Notes for reviewers

- The invite code `55SZFEEH5y` matches the one adopted in livepeer/website#94 and livepeer/docs#995.
- The badge still reads its member count from server ID `423160867534929930`, which is unchanged.